### PR TITLE
feat: centraliser pages config tenants + alertes email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ MAIL_ENCRYPTION=ssl
 MAIL_FROM_ADDRESS=support@klassci.com
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Alert emails (comma-separated, fallback: admin users emails)
+KLASSCI_ALERT_EMAILS=marcel.djedjeli@africandigitconsulting.com,bede.josias@africandigitconsulting.com
+
 # Production SSH/cPanel credentials
 PRODUCTION_HOST=web44.lws-hosting.com
 PRODUCTION_SSH_PORT=2083

--- a/SCHEDULER_ACTIVATION.md
+++ b/SCHEDULER_ACTIVATION.md
@@ -1,0 +1,65 @@
+# Activation du Scheduler Laravel — adminKlassci
+
+## Prérequis
+
+Le fichier `routes/console.php` contient déjà 7 tâches planifiées :
+
+| Tâche | Fréquence | Heure |
+|-------|-----------|-------|
+| Health check tous tenants | Toutes les heures | — |
+| Backup DB quotidien | Quotidien | 02:00 |
+| Backup full (DB + fichiers) | Hebdo (dimanche) | 03:00 |
+| Nettoyage backups expirés | Quotidien | 04:00 |
+| Stats update tous tenants | Toutes les heures | — |
+| Alertes tenants (quota, expiration, santé) | Quotidien | 09:00 |
+| Rotation logs tenants | Hebdo (dimanche) | 01:00 |
+
+## Activation en production (cPanel LWS)
+
+### Étape 1 — Accéder à cPanel
+
+1. Connexion SSH : `ssh c2569688c@web44.lws-hosting.com`
+2. Ou via cPanel web : section **Avancé > Tâches Cron**
+
+### Étape 2 — Ajouter la tâche cron
+
+```
+* * * * * /usr/local/bin/php /home/c2569688c/public_html/admin/artisan schedule:run >> /dev/null 2>&1
+```
+
+> **Important** : Utiliser `/usr/local/bin/php` (CLI), pas `php` (qui pointe vers LSAPI sur LWS).
+
+### Étape 3 — Vérifier
+
+```bash
+# Vérifier que le cron est actif
+crontab -l | grep schedule
+
+# Vérifier les logs après quelques minutes
+tail -f ~/public_html/admin/storage/logs/health-checks.log
+tail -f ~/public_html/admin/storage/logs/backups.log
+tail -f ~/public_html/admin/storage/logs/alerts.log
+```
+
+### Étape 4 — Test manuel
+
+```bash
+cd ~/public_html/admin
+
+# Tester le scheduler
+/usr/local/bin/php artisan schedule:list
+
+# Tester une commande individuellement
+/usr/local/bin/php artisan tenant:health-check --all
+/usr/local/bin/php artisan tenant:send-alerts --dry-run
+/usr/local/bin/php artisan tenant:backup --all --type=database_only
+```
+
+## En développement local
+
+```bash
+cd adminKlassci
+php artisan schedule:work
+```
+
+Cela exécute le scheduler en boucle (toutes les minutes) dans le terminal.

--- a/app/Console/Commands/SendTenantAlerts.php
+++ b/app/Console/Commands/SendTenantAlerts.php
@@ -9,13 +9,16 @@ use App\Models\User;
 use Filament\Notifications\Notification;
 use Filament\Notifications\Actions\Action;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Log;
 
 class SendTenantAlerts extends Command
 {
     protected $signature = 'tenant:send-alerts
-                            {--dry-run : Affiche les alertes sans les envoyer}';
+                            {--dry-run : Affiche les alertes sans les envoyer}
+                            {--no-email : Désactiver l\'envoi d\'email (notifications Filament uniquement)}';
 
-    protected $description = 'Envoie des notifications aux admins SaaS pour les quotas dépassés, abonnements expirants et tenants inactifs.';
+    protected $description = 'Envoie des notifications aux admins SaaS (Filament + email) pour les quotas dépassés, abonnements expirants et tenants inactifs.';
 
     public function handle(): int
     {
@@ -28,6 +31,7 @@ class SendTenantAlerts extends Command
 
         $dryRun = $this->option('dry-run');
         $alertCount = 0;
+        $emailAlerts = []; // Collecte pour l'email récapitulatif
 
         $activeTenants = Tenant::where('status', 'active')->get();
 
@@ -38,6 +42,7 @@ class SendTenantAlerts extends Command
 
                 $this->info("🔴 Quota dépassé: {$tenant->name} — {$quotaDetails}");
                 $alertCount++;
+                $emailAlerts[] = ['level' => 'danger', 'tenant' => $tenant->name, 'title' => 'Quota dépassé', 'message' => $quotaDetails];
 
                 if (!$dryRun) {
                     foreach ($admins as $admin) {
@@ -65,6 +70,7 @@ class SendTenantAlerts extends Command
 
                 $this->error("🚨 Abonnement expiré: {$tenant->name} — {$message}");
                 $alertCount++;
+                $emailAlerts[] = ['level' => 'danger', 'tenant' => $tenant->name, 'title' => 'Abonnement expiré', 'message' => $message];
 
                 if (!$dryRun) {
                     foreach ($admins as $admin) {
@@ -93,6 +99,7 @@ class SendTenantAlerts extends Command
 
                     $this->warn("⚠️  Expiration proche: {$tenant->name} — {$message}");
                     $alertCount++;
+                    $emailAlerts[] = ['level' => 'warning', 'tenant' => $tenant->name, 'title' => 'Abonnement expirant', 'message' => $message];
 
                     if (!$dryRun) {
                         foreach ($admins as $admin) {
@@ -124,6 +131,7 @@ class SendTenantAlerts extends Command
 
                 $this->line("💤 Inactif: {$tenant->name} — {$message}");
                 $alertCount++;
+                $emailAlerts[] = ['level' => 'info', 'tenant' => $tenant->name, 'title' => 'Tenant inactif', 'message' => $message];
 
                 if (!$dryRun) {
                     foreach ($admins as $admin) {
@@ -156,6 +164,7 @@ class SendTenantAlerts extends Command
 
                 $this->error("🔥 Health check KO: {$tenant->name} — {$message}");
                 $alertCount++;
+                $emailAlerts[] = ['level' => 'danger', 'tenant' => $tenant->name, 'title' => 'Site inaccessible', 'message' => $message];
 
                 if (!$dryRun) {
                     foreach ($admins as $admin) {
@@ -192,6 +201,7 @@ class SendTenantAlerts extends Command
 
                 $this->warn("💾 Backup absent: {$tenant->name} — {$message}");
                 $alertCount++;
+                $emailAlerts[] = ['level' => 'warning', 'tenant' => $tenant->name, 'title' => 'Backup manquant', 'message' => $message];
 
                 if (!$dryRun) {
                     foreach ($admins as $admin) {
@@ -212,11 +222,17 @@ class SendTenantAlerts extends Command
             }
         }
 
+        // Envoi email récapitulatif si des alertes existent
+        if ($alertCount > 0 && !$dryRun && !$this->option('no-email')) {
+            $this->sendEmailSummary($emailAlerts, $admins);
+        }
+
         if ($alertCount === 0) {
             $this->info('✅ Aucune alerte à envoyer.');
         } else {
             $mode = $dryRun ? '(dry-run — non envoyées)' : 'envoyées';
-            $this->info("📬 {$alertCount} alerte(s) {$mode} à {$admins->count()} admin(s).");
+            $emailStatus = (!$dryRun && !$this->option('no-email')) ? ' + email récapitulatif' : '';
+            $this->info("📬 {$alertCount} alerte(s) {$mode} à {$admins->count()} admin(s){$emailStatus}.");
         }
 
         return 0;
@@ -243,5 +259,60 @@ class SendTenantAlerts extends Command
         }
 
         return 'Limites dépassées : ' . implode(', ', $exceeded) . '.';
+    }
+
+    /**
+     * Envoie un email récapitulatif de toutes les alertes aux admins.
+     */
+    private function sendEmailSummary(array $alerts, $admins): void
+    {
+        if (empty($alerts)) {
+            return;
+        }
+
+        $recipientEmails = config('klassci.alert_emails', []);
+
+        // Fallback : emails des admins actifs
+        if (empty($recipientEmails)) {
+            $recipientEmails = $admins->pluck('email')->filter()->toArray();
+        }
+
+        if (empty($recipientEmails)) {
+            $this->warn('Aucune adresse email configurée pour les alertes.');
+            return;
+        }
+
+        $date = now()->format('d/m/Y H:i');
+        $count = count($alerts);
+
+        $body = "Rapport d'alertes KLASSCI — {$date}\n";
+        $body .= str_repeat('─', 50) . "\n\n";
+        $body .= "{$count} alerte(s) détectée(s) :\n\n";
+
+        foreach ($alerts as $alert) {
+            $icon = match ($alert['level']) {
+                'danger' => '🔴',
+                'warning' => '⚠️',
+                'info' => 'ℹ️',
+                default => '•',
+            };
+            $body .= "{$icon} [{$alert['tenant']}] {$alert['title']}\n";
+            $body .= "   {$alert['message']}\n\n";
+        }
+
+        $body .= str_repeat('─', 50) . "\n";
+        $body .= "Panel admin : " . config('app.url', 'https://admin.klassci.com') . "/admin\n";
+
+        try {
+            Mail::raw($body, function ($message) use ($recipientEmails, $count, $date) {
+                $message->to($recipientEmails)
+                    ->subject("[KLASSCI Admin] {$count} alerte(s) — {$date}");
+            });
+
+            $this->info("📧 Email récapitulatif envoyé à : " . implode(', ', $recipientEmails));
+        } catch (\Exception $e) {
+            Log::error('Échec envoi email alertes KLASSCI', ['error' => $e->getMessage()]);
+            $this->error("❌ Échec envoi email : {$e->getMessage()}");
+        }
     }
 }

--- a/app/Filament/Pages/TenantConfig/BulletinStylePage.php
+++ b/app/Filament/Pages/TenantConfig/BulletinStylePage.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Filament\Pages\TenantConfig;
+
+use App\Filament\Traits\TenantConfigTrait;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class BulletinStylePage extends Page
+{
+    use TenantConfigTrait;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+    protected static ?string $navigationLabel = 'Style Bulletin';
+    protected static ?string $navigationGroup = 'Configuration Tenants';
+    protected static ?int $navigationSort = 3;
+    protected static string $view = 'filament.pages.tenant-config.bulletin-style';
+    protected static ?string $title = 'Style du Bulletin PDF';
+
+    public string $bulletinStyle = '';
+    public array $tenants = [];
+
+    public function mount(): void
+    {
+        $this->tenants = $this->getActiveTenants();
+    }
+
+    public function updatedSelectedTenantId(): void
+    {
+        $this->bulletinStyle = '';
+        $this->loadConfig();
+    }
+
+    public function loadConfig(): void
+    {
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        $setting = $db->table('settings')
+            ->where('key', 'bulletin_style')
+            ->first();
+
+        $this->bulletinStyle = $setting->value ?? 'yakro';
+        $this->closeTenantConnection();
+    }
+
+    public function saveConfig(): void
+    {
+        if (! $this->selectedTenantId) {
+            Notification::make()->title('Sélectionnez un tenant')->warning()->send();
+            return;
+        }
+
+        if (! in_array($this->bulletinStyle, ['yakro', 'abidjan'])) {
+            Notification::make()->title('Style invalide')->danger()->send();
+            return;
+        }
+
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        $tenant = $this->getSelectedTenant();
+
+        $db->table('settings')
+            ->updateOrInsert(
+                ['key' => 'bulletin_style'],
+                [
+                    'value' => $this->bulletinStyle,
+                    'type' => 'string',
+                    'group' => 'bulletin',
+                    'category' => 'bulletin',
+                    'updated_at' => now(),
+                ]
+            );
+
+        $this->closeTenantConnection();
+
+        $this->logConfigChange(
+            'config_update',
+            "Style bulletin changé en '{$this->bulletinStyle}' pour {$tenant->name}",
+            ['setting' => 'bulletin_style', 'value' => $this->bulletinStyle]
+        );
+
+        Notification::make()
+            ->title('Style bulletin mis à jour')
+            ->body("Le style '{$this->bulletinStyle}' a été appliqué à {$tenant->name}.")
+            ->success()
+            ->send();
+    }
+}

--- a/app/Filament/Pages/TenantConfig/BulletinStylePage.php
+++ b/app/Filament/Pages/TenantConfig/BulletinStylePage.php
@@ -18,15 +18,10 @@ class BulletinStylePage extends Page
     protected static ?string $title = 'Style du Bulletin PDF';
 
     public string $bulletinStyle = '';
-    public array $tenants = [];
-
-    public function mount(): void
-    {
-        $this->tenants = $this->getActiveTenants();
-    }
 
     public function updatedSelectedTenantId(): void
     {
+        $this->resetTenantState();
         $this->bulletinStyle = '';
         $this->loadConfig();
     }
@@ -38,20 +33,20 @@ class BulletinStylePage extends Page
             return;
         }
 
-        $setting = $db->table('settings')
-            ->where('key', 'bulletin_style')
-            ->first();
+        try {
+            $setting = $db->table('settings')
+                ->where('key', 'bulletin_style')
+                ->first();
 
-        $this->bulletinStyle = $setting->value ?? 'yakro';
-        $this->closeTenantConnection();
+            $this->bulletinStyle = $setting->value ?? 'yakro';
+        } finally {
+            $this->closeTenantConnection();
+        }
     }
 
     public function saveConfig(): void
     {
-        if (! $this->selectedTenantId) {
-            Notification::make()->title('Sélectionnez un tenant')->warning()->send();
-            return;
-        }
+        if (! $this->requireTenant()) return;
 
         if (! in_array($this->bulletinStyle, ['yakro', 'abidjan'])) {
             Notification::make()->title('Style invalide')->danger()->send();
@@ -65,19 +60,21 @@ class BulletinStylePage extends Page
 
         $tenant = $this->getSelectedTenant();
 
-        $db->table('settings')
-            ->updateOrInsert(
-                ['key' => 'bulletin_style'],
-                [
-                    'value' => $this->bulletinStyle,
-                    'type' => 'string',
-                    'group' => 'bulletin',
-                    'category' => 'bulletin',
-                    'updated_at' => now(),
-                ]
-            );
-
-        $this->closeTenantConnection();
+        try {
+            $db->table('settings')
+                ->updateOrInsert(
+                    ['key' => 'bulletin_style'],
+                    [
+                        'value' => $this->bulletinStyle,
+                        'type' => 'string',
+                        'group' => 'bulletin',
+                        'category' => 'bulletin',
+                        'updated_at' => now(),
+                    ]
+                );
+        } finally {
+            $this->closeTenantConnection();
+        }
 
         $this->logConfigChange(
             'config_update',

--- a/app/Filament/Pages/TenantConfig/MatriculeConfigPage.php
+++ b/app/Filament/Pages/TenantConfig/MatriculeConfigPage.php
@@ -17,7 +17,6 @@ class MatriculeConfigPage extends Page
     protected static string $view = 'filament.pages.tenant-config.matricule-config';
     protected static ?string $title = 'Configuration des Matricules';
 
-    public array $tenants = [];
     public array $configs = [];
 
     // Form fields
@@ -30,13 +29,9 @@ class MatriculeConfigPage extends Page
     public ?int $editingId = null;
     public bool $showForm = false;
 
-    public function mount(): void
-    {
-        $this->tenants = $this->getActiveTenants();
-    }
-
     public function updatedSelectedTenantId(): void
     {
+        $this->resetTenantState();
         $this->configs = [];
         $this->resetForm();
         $this->loadConfigs();
@@ -62,9 +57,9 @@ class MatriculeConfigPage extends Page
                 ->body('La table esbtp_matricule_configs n\'existe pas pour ce tenant.')
                 ->warning()
                 ->send();
+        } finally {
+            $this->closeTenantConnection();
         }
-
-        $this->closeTenantConnection();
     }
 
     public function openForm(?int $id = null): void
@@ -101,6 +96,8 @@ class MatriculeConfigPage extends Page
 
     public function saveConfig(): void
     {
+        if (! $this->requireTenant()) return;
+
         $this->validate([
             'formNiveauCode' => 'required|max:50',
             'formNiveauName' => 'required|max:100',
@@ -126,18 +123,20 @@ class MatriculeConfigPage extends Page
             'updated_at' => now(),
         ];
 
-        if ($this->editingId) {
-            $db->table('esbtp_matricule_configs')
-                ->where('id', $this->editingId)
-                ->update($data);
-            $action = 'updated';
-        } else {
-            $data['created_at'] = now();
-            $db->table('esbtp_matricule_configs')->insert($data);
-            $action = 'created';
+        try {
+            if ($this->editingId) {
+                $db->table('esbtp_matricule_configs')
+                    ->where('id', $this->editingId)
+                    ->update($data);
+                $action = 'updated';
+            } else {
+                $data['created_at'] = now();
+                $db->table('esbtp_matricule_configs')->insert($data);
+                $action = 'created';
+            }
+        } finally {
+            $this->closeTenantConnection();
         }
-
-        $this->closeTenantConnection();
 
         $this->logConfigChange(
             'matricule_config_' . $action,
@@ -157,21 +156,26 @@ class MatriculeConfigPage extends Page
 
     public function deleteConfig(int $id): void
     {
+        if (! $this->requireTenant()) return;
+
+        $config = collect($this->configs)->firstWhere('id', $id);
+        $tenant = $this->getSelectedTenant();
+
         $db = $this->tenantDb();
         if (! $db) {
             return;
         }
 
-        $tenant = $this->getSelectedTenant();
-        $config = $db->table('esbtp_matricule_configs')->where('id', $id)->first();
-
-        $db->table('esbtp_matricule_configs')->where('id', $id)->delete();
-        $this->closeTenantConnection();
+        try {
+            $db->table('esbtp_matricule_configs')->where('id', $id)->delete();
+        } finally {
+            $this->closeTenantConnection();
+        }
 
         $this->logConfigChange(
             'matricule_config_deleted',
-            "Config matricule supprimée (niveau {$config->niveau_etude_code}) sur {$tenant->name}",
-            ['deleted_id' => $id, 'niveau' => $config->niveau_etude_code ?? 'unknown']
+            "Config matricule supprimée (niveau " . ($config['niveau_etude_code'] ?? 'unknown') . ") sur {$tenant->name}",
+            ['deleted_id' => $id, 'niveau' => $config['niveau_etude_code'] ?? 'unknown']
         );
 
         Notification::make()

--- a/app/Filament/Pages/TenantConfig/MatriculeConfigPage.php
+++ b/app/Filament/Pages/TenantConfig/MatriculeConfigPage.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Filament\Pages\TenantConfig;
+
+use App\Filament\Traits\TenantConfigTrait;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class MatriculeConfigPage extends Page
+{
+    use TenantConfigTrait;
+
+    protected static ?string $navigationIcon = 'heroicon-o-identification';
+    protected static ?string $navigationLabel = 'Config Matricule';
+    protected static ?string $navigationGroup = 'Configuration Tenants';
+    protected static ?int $navigationSort = 2;
+    protected static string $view = 'filament.pages.tenant-config.matricule-config';
+    protected static ?string $title = 'Configuration des Matricules';
+
+    public array $tenants = [];
+    public array $configs = [];
+
+    // Form fields
+    public string $formNiveauCode = '';
+    public string $formNiveauName = '';
+    public string $formPrefixe = '';
+    public int $formAnneeFormat = 2;
+    public int $formNumeroDigits = 4;
+    public string $formDescription = '';
+    public ?int $editingId = null;
+    public bool $showForm = false;
+
+    public function mount(): void
+    {
+        $this->tenants = $this->getActiveTenants();
+    }
+
+    public function updatedSelectedTenantId(): void
+    {
+        $this->configs = [];
+        $this->resetForm();
+        $this->loadConfigs();
+    }
+
+    public function loadConfigs(): void
+    {
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        try {
+            $this->configs = $db->table('esbtp_matricule_configs')
+                ->orderBy('niveau_etude_code')
+                ->get()
+                ->map(fn ($c) => (array) $c)
+                ->toArray();
+        } catch (\Exception $e) {
+            $this->configs = [];
+            Notification::make()
+                ->title('Table non trouvée')
+                ->body('La table esbtp_matricule_configs n\'existe pas pour ce tenant.')
+                ->warning()
+                ->send();
+        }
+
+        $this->closeTenantConnection();
+    }
+
+    public function openForm(?int $id = null): void
+    {
+        $this->resetForm();
+
+        if ($id) {
+            $config = collect($this->configs)->firstWhere('id', $id);
+            if ($config) {
+                $this->editingId = $id;
+                $this->formNiveauCode = $config['niveau_etude_code'] ?? '';
+                $this->formNiveauName = $config['niveau_etude_name'] ?? '';
+                $this->formPrefixe = $config['prefixe'] ?? '';
+                $this->formAnneeFormat = (int) ($config['annee_format'] ?? 2);
+                $this->formNumeroDigits = (int) ($config['numero_digits'] ?? 4);
+                $this->formDescription = $config['description'] ?? '';
+            }
+        }
+
+        $this->showForm = true;
+    }
+
+    public function resetForm(): void
+    {
+        $this->editingId = null;
+        $this->formNiveauCode = '';
+        $this->formNiveauName = '';
+        $this->formPrefixe = '';
+        $this->formAnneeFormat = 2;
+        $this->formNumeroDigits = 4;
+        $this->formDescription = '';
+        $this->showForm = false;
+    }
+
+    public function saveConfig(): void
+    {
+        $this->validate([
+            'formNiveauCode' => 'required|max:50',
+            'formNiveauName' => 'required|max:100',
+            'formPrefixe' => 'nullable|max:10',
+            'formAnneeFormat' => 'required|in:2,4',
+            'formNumeroDigits' => 'required|integer|min:3|max:6',
+        ]);
+
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        $tenant = $this->getSelectedTenant();
+        $data = [
+            'niveau_etude_code' => strtoupper($this->formNiveauCode),
+            'niveau_etude_name' => $this->formNiveauName,
+            'prefixe' => $this->formPrefixe ?: null,
+            'annee_format' => $this->formAnneeFormat,
+            'numero_digits' => $this->formNumeroDigits,
+            'description' => $this->formDescription ?: null,
+            'is_active' => true,
+            'updated_at' => now(),
+        ];
+
+        if ($this->editingId) {
+            $db->table('esbtp_matricule_configs')
+                ->where('id', $this->editingId)
+                ->update($data);
+            $action = 'updated';
+        } else {
+            $data['created_at'] = now();
+            $db->table('esbtp_matricule_configs')->insert($data);
+            $action = 'created';
+        }
+
+        $this->closeTenantConnection();
+
+        $this->logConfigChange(
+            'matricule_config_' . $action,
+            "Config matricule {$action} pour niveau {$data['niveau_etude_code']} sur {$tenant->name}",
+            $data
+        );
+
+        Notification::make()
+            ->title('Configuration sauvegardée')
+            ->body("Matricule {$data['niveau_etude_code']} {$action} pour {$tenant->name}.")
+            ->success()
+            ->send();
+
+        $this->resetForm();
+        $this->loadConfigs();
+    }
+
+    public function deleteConfig(int $id): void
+    {
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        $tenant = $this->getSelectedTenant();
+        $config = $db->table('esbtp_matricule_configs')->where('id', $id)->first();
+
+        $db->table('esbtp_matricule_configs')->where('id', $id)->delete();
+        $this->closeTenantConnection();
+
+        $this->logConfigChange(
+            'matricule_config_deleted',
+            "Config matricule supprimée (niveau {$config->niveau_etude_code}) sur {$tenant->name}",
+            ['deleted_id' => $id, 'niveau' => $config->niveau_etude_code ?? 'unknown']
+        );
+
+        Notification::make()
+            ->title('Configuration supprimée')
+            ->success()
+            ->send();
+
+        $this->loadConfigs();
+    }
+
+    public function generatePreview(): string
+    {
+        $year = $this->formAnneeFormat === 4 ? date('Y') : substr(date('Y'), -2);
+        $prefix = $this->formPrefixe ?: '';
+        $code = strtoupper(substr($this->formNiveauCode, 0, 4));
+        $number = str_pad('1', $this->formNumeroDigits, '0', STR_PAD_LEFT);
+
+        return "M{$prefix}{$code}{$year}-{$number}";
+    }
+}

--- a/app/Filament/Pages/TenantConfig/RolePermissionPage.php
+++ b/app/Filament/Pages/TenantConfig/RolePermissionPage.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace App\Filament\Pages\TenantConfig;
+
+use App\Filament\Traits\TenantConfigTrait;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Facades\DB;
+
+class RolePermissionPage extends Page
+{
+    use TenantConfigTrait;
+
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
+    protected static ?string $navigationLabel = 'Rôles & Permissions';
+    protected static ?string $navigationGroup = 'Configuration Tenants';
+    protected static ?int $navigationSort = 1;
+    protected static string $view = 'filament.pages.tenant-config.role-permission';
+    protected static ?string $title = 'Gestion des Rôles & Permissions';
+
+    public array $tenants = [];
+    public array $roles = [];
+    public array $permissions = [];
+    public array $groupedPermissions = [];
+    public ?int $selectedRoleId = null;
+    public string $selectedRoleName = '';
+    public array $rolePermissionIds = [];
+
+    public function mount(): void
+    {
+        $this->tenants = $this->getActiveTenants();
+    }
+
+    public function updatedSelectedTenantId(): void
+    {
+        $this->roles = [];
+        $this->permissions = [];
+        $this->groupedPermissions = [];
+        $this->selectedRoleId = null;
+        $this->selectedRoleName = '';
+        $this->rolePermissionIds = [];
+        $this->loadRolesAndPermissions();
+    }
+
+    public function loadRolesAndPermissions(): void
+    {
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        try {
+            // Charger les rôles
+            $this->roles = $db->table('roles')
+                ->orderBy('name')
+                ->get(['id', 'name', 'guard_name'])
+                ->map(fn ($r) => (array) $r)
+                ->toArray();
+
+            // Charger les permissions
+            $perms = $db->table('permissions')
+                ->orderBy('name')
+                ->get(['id', 'name', 'guard_name'])
+                ->map(fn ($p) => (array) $p)
+                ->toArray();
+
+            $this->permissions = $perms;
+
+            // Grouper par catégorie (premier segment avant le point ou underscore)
+            $grouped = [];
+            foreach ($perms as $perm) {
+                $name = $perm['name'];
+                // Catégoriser par premier segment
+                if (str_contains($name, '.')) {
+                    $group = explode('.', $name)[0];
+                } elseif (str_contains($name, '_')) {
+                    $parts = explode('_', $name);
+                    $group = $parts[count($parts) - 1]; // last word for "view_own_grades" → "grades"
+                } else {
+                    $group = 'Autres';
+                }
+                $group = ucfirst($group);
+                $grouped[$group][] = $perm;
+            }
+            ksort($grouped);
+            $this->groupedPermissions = $grouped;
+
+        } catch (\Exception $e) {
+            Notification::make()
+                ->title('Erreur')
+                ->body('Tables Spatie non trouvées: ' . $e->getMessage())
+                ->danger()
+                ->send();
+        }
+
+        $this->closeTenantConnection();
+    }
+
+    public function selectRole(int $roleId): void
+    {
+        $this->selectedRoleId = $roleId;
+        $role = collect($this->roles)->firstWhere('id', $roleId);
+        $this->selectedRoleName = $role['name'] ?? '';
+
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        // Charger les permissions du rôle
+        $this->rolePermissionIds = $db->table('role_has_permissions')
+            ->where('role_id', $roleId)
+            ->pluck('permission_id')
+            ->map(fn ($id) => (int) $id)
+            ->toArray();
+
+        $this->closeTenantConnection();
+    }
+
+    public function togglePermission(int $permissionId): void
+    {
+        if (in_array($permissionId, $this->rolePermissionIds)) {
+            $this->rolePermissionIds = array_values(array_diff($this->rolePermissionIds, [$permissionId]));
+        } else {
+            $this->rolePermissionIds[] = $permissionId;
+        }
+    }
+
+    public function savePermissions(): void
+    {
+        if (! $this->selectedRoleId || ! $this->selectedTenantId) {
+            Notification::make()->title('Sélectionnez un rôle')->warning()->send();
+            return;
+        }
+
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        $tenant = $this->getSelectedTenant();
+
+        try {
+            $db->beginTransaction();
+
+            // Supprimer les anciennes permissions du rôle
+            $db->table('role_has_permissions')
+                ->where('role_id', $this->selectedRoleId)
+                ->delete();
+
+            // Insérer les nouvelles
+            $inserts = [];
+            foreach ($this->rolePermissionIds as $permId) {
+                $inserts[] = [
+                    'permission_id' => $permId,
+                    'role_id' => $this->selectedRoleId,
+                ];
+            }
+
+            if (! empty($inserts)) {
+                $db->table('role_has_permissions')->insert($inserts);
+            }
+
+            $db->commit();
+
+            // Clear Spatie permission cache
+            // On ne peut pas appeler artisan sur le tenant distant, mais on peut vider le cache table
+            try {
+                $db->table('cache')->where('key', 'like', '%spatie%permission%')->delete();
+            } catch (\Exception $e) {
+                // Cache table might not exist, ignore
+            }
+
+            $this->closeTenantConnection();
+
+            $this->logConfigChange(
+                'role_permissions_updated',
+                "Permissions du rôle '{$this->selectedRoleName}' mises à jour sur {$tenant->name} (" . count($this->rolePermissionIds) . " permissions)",
+                ['role' => $this->selectedRoleName, 'permission_count' => count($this->rolePermissionIds)]
+            );
+
+            Notification::make()
+                ->title('Permissions sauvegardées')
+                ->body(count($this->rolePermissionIds) . " permissions assignées au rôle '{$this->selectedRoleName}' sur {$tenant->name}.")
+                ->success()
+                ->send();
+
+        } catch (\Exception $e) {
+            $db->rollBack();
+            $this->closeTenantConnection();
+
+            Notification::make()
+                ->title('Erreur')
+                ->body('Erreur lors de la sauvegarde: ' . $e->getMessage())
+                ->danger()
+                ->send();
+        }
+    }
+}

--- a/app/Filament/Pages/TenantConfig/RolePermissionPage.php
+++ b/app/Filament/Pages/TenantConfig/RolePermissionPage.php
@@ -18,7 +18,6 @@ class RolePermissionPage extends Page
     protected static string $view = 'filament.pages.tenant-config.role-permission';
     protected static ?string $title = 'Gestion des Rôles & Permissions';
 
-    public array $tenants = [];
     public array $roles = [];
     public array $permissions = [];
     public array $groupedPermissions = [];
@@ -26,13 +25,9 @@ class RolePermissionPage extends Page
     public string $selectedRoleName = '';
     public array $rolePermissionIds = [];
 
-    public function mount(): void
-    {
-        $this->tenants = $this->getActiveTenants();
-    }
-
     public function updatedSelectedTenantId(): void
     {
+        $this->resetTenantState();
         $this->roles = [];
         $this->permissions = [];
         $this->groupedPermissions = [];
@@ -50,14 +45,12 @@ class RolePermissionPage extends Page
         }
 
         try {
-            // Charger les rôles
             $this->roles = $db->table('roles')
                 ->orderBy('name')
                 ->get(['id', 'name', 'guard_name'])
                 ->map(fn ($r) => (array) $r)
                 ->toArray();
 
-            // Charger les permissions
             $perms = $db->table('permissions')
                 ->orderBy('name')
                 ->get(['id', 'name', 'guard_name'])
@@ -66,16 +59,11 @@ class RolePermissionPage extends Page
 
             $this->permissions = $perms;
 
-            // Grouper par catégorie (premier segment avant le point ou underscore)
             $grouped = [];
             foreach ($perms as $perm) {
                 $name = $perm['name'];
-                // Catégoriser par premier segment
                 if (str_contains($name, '.')) {
                     $group = explode('.', $name)[0];
-                } elseif (str_contains($name, '_')) {
-                    $parts = explode('_', $name);
-                    $group = $parts[count($parts) - 1]; // last word for "view_own_grades" → "grades"
                 } else {
                     $group = 'Autres';
                 }
@@ -91,9 +79,9 @@ class RolePermissionPage extends Page
                 ->body('Tables Spatie non trouvées: ' . $e->getMessage())
                 ->danger()
                 ->send();
+        } finally {
+            $this->closeTenantConnection();
         }
-
-        $this->closeTenantConnection();
     }
 
     public function selectRole(int $roleId): void
@@ -107,14 +95,15 @@ class RolePermissionPage extends Page
             return;
         }
 
-        // Charger les permissions du rôle
-        $this->rolePermissionIds = $db->table('role_has_permissions')
-            ->where('role_id', $roleId)
-            ->pluck('permission_id')
-            ->map(fn ($id) => (int) $id)
-            ->toArray();
-
-        $this->closeTenantConnection();
+        try {
+            $this->rolePermissionIds = $db->table('role_has_permissions')
+                ->where('role_id', $roleId)
+                ->pluck('permission_id')
+                ->map(fn ($id) => (int) $id)
+                ->toArray();
+        } finally {
+            $this->closeTenantConnection();
+        }
     }
 
     public function togglePermission(int $permissionId): void
@@ -128,7 +117,9 @@ class RolePermissionPage extends Page
 
     public function savePermissions(): void
     {
-        if (! $this->selectedRoleId || ! $this->selectedTenantId) {
+        if (! $this->requireTenant()) return;
+
+        if (! $this->selectedRoleId) {
             Notification::make()->title('Sélectionnez un rôle')->warning()->send();
             return;
         }
@@ -143,12 +134,10 @@ class RolePermissionPage extends Page
         try {
             $db->beginTransaction();
 
-            // Supprimer les anciennes permissions du rôle
             $db->table('role_has_permissions')
                 ->where('role_id', $this->selectedRoleId)
                 ->delete();
 
-            // Insérer les nouvelles
             $inserts = [];
             foreach ($this->rolePermissionIds as $permId) {
                 $inserts[] = [
@@ -164,36 +153,34 @@ class RolePermissionPage extends Page
             $db->commit();
 
             // Clear Spatie permission cache
-            // On ne peut pas appeler artisan sur le tenant distant, mais on peut vider le cache table
             try {
                 $db->table('cache')->where('key', 'like', '%spatie%permission%')->delete();
             } catch (\Exception $e) {
-                // Cache table might not exist, ignore
+                // Cache table might not exist
             }
-
-            $this->closeTenantConnection();
-
-            $this->logConfigChange(
-                'role_permissions_updated',
-                "Permissions du rôle '{$this->selectedRoleName}' mises à jour sur {$tenant->name} (" . count($this->rolePermissionIds) . " permissions)",
-                ['role' => $this->selectedRoleName, 'permission_count' => count($this->rolePermissionIds)]
-            );
-
-            Notification::make()
-                ->title('Permissions sauvegardées')
-                ->body(count($this->rolePermissionIds) . " permissions assignées au rôle '{$this->selectedRoleName}' sur {$tenant->name}.")
-                ->success()
-                ->send();
-
         } catch (\Exception $e) {
             $db->rollBack();
-            $this->closeTenantConnection();
 
             Notification::make()
                 ->title('Erreur')
                 ->body('Erreur lors de la sauvegarde: ' . $e->getMessage())
                 ->danger()
                 ->send();
+            return;
+        } finally {
+            $this->closeTenantConnection();
         }
+
+        $this->logConfigChange(
+            'role_permissions_updated',
+            "Permissions du rôle '{$this->selectedRoleName}' mises à jour sur {$tenant->name} (" . count($this->rolePermissionIds) . " permissions)",
+            ['role' => $this->selectedRoleName, 'permission_count' => count($this->rolePermissionIds)]
+        );
+
+        Notification::make()
+            ->title('Permissions sauvegardées')
+            ->body(count($this->rolePermissionIds) . " permissions assignées au rôle '{$this->selectedRoleName}' sur {$tenant->name}.")
+            ->success()
+            ->send();
     }
 }

--- a/app/Filament/Pages/TenantConfig/SettingsPage.php
+++ b/app/Filament/Pages/TenantConfig/SettingsPage.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Filament\Pages\TenantConfig;
+
+use App\Filament\Traits\TenantConfigTrait;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class SettingsPage extends Page
+{
+    use TenantConfigTrait;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static ?string $navigationLabel = 'Settings PDF';
+    protected static ?string $navigationGroup = 'Configuration Tenants';
+    protected static ?int $navigationSort = 4;
+    protected static string $view = 'filament.pages.tenant-config.settings';
+    protected static ?string $title = 'Paramètres PDF & Bulletin';
+
+    public array $tenants = [];
+    public array $settings = [];
+    public array $formValues = [];
+
+    protected array $settingGroups = [
+        'pdf_colors' => [
+            'label' => 'Couleurs PDF',
+            'icon' => 'heroicon-o-swatch',
+            'keys' => [
+                'pdf_primary_color' => ['label' => 'Couleur primaire', 'type' => 'color', 'default' => '#0453cb'],
+                'pdf_secondary_color' => ['label' => 'Couleur secondaire', 'type' => 'color', 'default' => '#64748b'],
+                'pdf_accent_color' => ['label' => 'Couleur accent', 'type' => 'color', 'default' => '#f59e0b'],
+                'pdf_text_color' => ['label' => 'Couleur texte', 'type' => 'color', 'default' => '#1f2937'],
+                'pdf_header_bg_color' => ['label' => 'Fond en-tête', 'type' => 'color', 'default' => '#0453cb'],
+                'pdf_header_text_color' => ['label' => 'Texte en-tête', 'type' => 'color', 'default' => '#ffffff'],
+            ],
+        ],
+        'bulletin_display' => [
+            'label' => 'Affichage Bulletin',
+            'icon' => 'heroicon-o-eye',
+            'keys' => [
+                'bulletin_show_logo' => ['label' => 'Logo', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_header' => ['label' => 'En-tête', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_republic_info' => ['label' => 'Info République', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_ministry_info' => ['label' => 'Info Ministère', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_school_info' => ['label' => 'Info École', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_student_info' => ['label' => 'Info Étudiant', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_matricule' => ['label' => 'Matricule', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_birth_date' => ['label' => 'Date de naissance', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_teachers' => ['label' => 'Noms enseignants', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_absences' => ['label' => 'Absences', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_statistics' => ['label' => 'Statistiques classe', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_signature' => ['label' => 'Signature', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_council_decision' => ['label' => 'Décision du conseil', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_highest_average' => ['label' => 'Meilleure moyenne', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_lowest_average' => ['label' => 'Plus basse moyenne', 'type' => 'boolean', 'default' => '1'],
+                'bulletin_show_class_average' => ['label' => 'Moyenne classe', 'type' => 'boolean', 'default' => '1'],
+            ],
+        ],
+        'bulletin_weights' => [
+            'label' => 'Poids Semestres',
+            'icon' => 'heroicon-o-scale',
+            'keys' => [
+                'bulletin_semester1_weight' => ['label' => 'Poids Semestre 1', 'type' => 'number', 'default' => '1'],
+                'bulletin_semester2_weight' => ['label' => 'Poids Semestre 2', 'type' => 'number', 'default' => '1'],
+            ],
+        ],
+        'certificat' => [
+            'label' => 'Certificat de scolarité',
+            'icon' => 'heroicon-o-academic-cap',
+            'keys' => [
+                'certificat_show_classe' => ['label' => 'Afficher classe', 'type' => 'boolean', 'default' => '1'],
+                'certificat_show_niveau' => ['label' => 'Afficher niveau', 'type' => 'boolean', 'default' => '1'],
+                'certificat_show_filiere' => ['label' => 'Afficher filière', 'type' => 'boolean', 'default' => '1'],
+            ],
+        ],
+    ];
+
+    public function mount(): void
+    {
+        $this->tenants = $this->getActiveTenants();
+    }
+
+    public function updatedSelectedTenantId(): void
+    {
+        $this->formValues = [];
+        $this->loadSettings();
+    }
+
+    public function getSettingGroups(): array
+    {
+        return $this->settingGroups;
+    }
+
+    public function loadSettings(): void
+    {
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        try {
+            $allKeys = [];
+            foreach ($this->settingGroups as $group) {
+                $allKeys = array_merge($allKeys, array_keys($group['keys']));
+            }
+
+            $dbSettings = $db->table('settings')
+                ->whereIn('key', $allKeys)
+                ->pluck('value', 'key')
+                ->toArray();
+
+            // Merge DB values with defaults
+            $this->formValues = [];
+            foreach ($this->settingGroups as $group) {
+                foreach ($group['keys'] as $key => $meta) {
+                    $this->formValues[$key] = $dbSettings[$key] ?? $meta['default'];
+                }
+            }
+        } catch (\Exception $e) {
+            Notification::make()
+                ->title('Erreur')
+                ->body('Impossible de charger les settings: ' . $e->getMessage())
+                ->danger()
+                ->send();
+        }
+
+        $this->closeTenantConnection();
+    }
+
+    public function saveSettings(): void
+    {
+        if (! $this->selectedTenantId) {
+            Notification::make()->title('Sélectionnez un tenant')->warning()->send();
+            return;
+        }
+
+        $db = $this->tenantDb();
+        if (! $db) {
+            return;
+        }
+
+        $tenant = $this->getSelectedTenant();
+        $updated = 0;
+
+        foreach ($this->settingGroups as $groupKey => $group) {
+            foreach ($group['keys'] as $key => $meta) {
+                $value = $this->formValues[$key] ?? $meta['default'];
+
+                $db->table('settings')->updateOrInsert(
+                    ['key' => $key],
+                    [
+                        'value' => $value,
+                        'type' => $meta['type'] === 'color' ? 'string' : $meta['type'],
+                        'group' => $groupKey,
+                        'category' => $groupKey,
+                        'updated_at' => now(),
+                    ]
+                );
+                $updated++;
+            }
+        }
+
+        $this->closeTenantConnection();
+
+        $this->logConfigChange(
+            'settings_bulk_update',
+            "{$updated} settings mis à jour pour {$tenant->name}",
+            ['count' => $updated, 'groups' => array_keys($this->settingGroups)]
+        );
+
+        Notification::make()
+            ->title('Paramètres sauvegardés')
+            ->body("{$updated} paramètres mis à jour pour {$tenant->name}.")
+            ->success()
+            ->send();
+    }
+}

--- a/app/Filament/Pages/TenantConfig/SettingsPage.php
+++ b/app/Filament/Pages/TenantConfig/SettingsPage.php
@@ -17,7 +17,6 @@ class SettingsPage extends Page
     protected static string $view = 'filament.pages.tenant-config.settings';
     protected static ?string $title = 'Paramètres PDF & Bulletin';
 
-    public array $tenants = [];
     public array $settings = [];
     public array $formValues = [];
 
@@ -75,13 +74,9 @@ class SettingsPage extends Page
         ],
     ];
 
-    public function mount(): void
-    {
-        $this->tenants = $this->getActiveTenants();
-    }
-
     public function updatedSelectedTenantId(): void
     {
+        $this->resetTenantState();
         $this->formValues = [];
         $this->loadSettings();
     }
@@ -109,7 +104,6 @@ class SettingsPage extends Page
                 ->pluck('value', 'key')
                 ->toArray();
 
-            // Merge DB values with defaults
             $this->formValues = [];
             foreach ($this->settingGroups as $group) {
                 foreach ($group['keys'] as $key => $meta) {
@@ -122,17 +116,14 @@ class SettingsPage extends Page
                 ->body('Impossible de charger les settings: ' . $e->getMessage())
                 ->danger()
                 ->send();
+        } finally {
+            $this->closeTenantConnection();
         }
-
-        $this->closeTenantConnection();
     }
 
     public function saveSettings(): void
     {
-        if (! $this->selectedTenantId) {
-            Notification::make()->title('Sélectionnez un tenant')->warning()->send();
-            return;
-        }
+        if (! $this->requireTenant()) return;
 
         $db = $this->tenantDb();
         if (! $db) {
@@ -140,37 +131,36 @@ class SettingsPage extends Page
         }
 
         $tenant = $this->getSelectedTenant();
-        $updated = 0;
 
-        foreach ($this->settingGroups as $groupKey => $group) {
-            foreach ($group['keys'] as $key => $meta) {
-                $value = $this->formValues[$key] ?? $meta['default'];
-
-                $db->table('settings')->updateOrInsert(
-                    ['key' => $key],
-                    [
-                        'value' => $value,
+        try {
+            $upsertData = [];
+            foreach ($this->settingGroups as $groupKey => $group) {
+                foreach ($group['keys'] as $key => $meta) {
+                    $upsertData[] = [
+                        'key' => $key,
+                        'value' => $this->formValues[$key] ?? $meta['default'],
                         'type' => $meta['type'] === 'color' ? 'string' : $meta['type'],
                         'group' => $groupKey,
                         'category' => $groupKey,
                         'updated_at' => now(),
-                    ]
-                );
-                $updated++;
+                    ];
+                }
             }
-        }
 
-        $this->closeTenantConnection();
+            $db->table('settings')->upsert($upsertData, ['key'], ['value', 'type', 'group', 'category', 'updated_at']);
+        } finally {
+            $this->closeTenantConnection();
+        }
 
         $this->logConfigChange(
             'settings_bulk_update',
-            "{$updated} settings mis à jour pour {$tenant->name}",
-            ['count' => $updated, 'groups' => array_keys($this->settingGroups)]
+            count($upsertData) . " settings mis à jour pour {$tenant->name}",
+            ['count' => count($upsertData), 'groups' => array_keys($this->settingGroups)]
         );
 
         Notification::make()
             ->title('Paramètres sauvegardés')
-            ->body("{$updated} paramètres mis à jour pour {$tenant->name}.")
+            ->body(count($upsertData) . " paramètres mis à jour pour {$tenant->name}.")
             ->success()
             ->send();
     }

--- a/app/Filament/Traits/TenantConfigTrait.php
+++ b/app/Filament/Traits/TenantConfigTrait.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Filament\Traits;
+
+use App\Models\Tenant;
+use App\Models\TenantActivityLog;
+use App\Services\TenantConnectionManager;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+trait TenantConfigTrait
+{
+    public ?int $selectedTenantId = null;
+
+    protected ?string $tenantConnectionName = null;
+
+    public function getActiveTenants(): array
+    {
+        return Tenant::active()
+            ->orderBy('name')
+            ->get(['id', 'code', 'name'])
+            ->map(fn ($t) => ['id' => $t->id, 'code' => $t->code, 'name' => $t->name])
+            ->toArray();
+    }
+
+    public function getSelectedTenant(): ?Tenant
+    {
+        if (! $this->selectedTenantId) {
+            return null;
+        }
+
+        return Tenant::find($this->selectedTenantId);
+    }
+
+    protected function connectToTenant(): ?string
+    {
+        $tenant = $this->getSelectedTenant();
+        if (! $tenant) {
+            return null;
+        }
+
+        try {
+            $manager = app(TenantConnectionManager::class);
+            $this->tenantConnectionName = $manager->createConnection($tenant);
+            return $this->tenantConnectionName;
+        } catch (\Exception $e) {
+            Log::error("Failed to connect to tenant {$tenant->code}", ['error' => $e->getMessage()]);
+            Notification::make()
+                ->title('Erreur de connexion')
+                ->body("Impossible de se connecter à la base de {$tenant->name}: {$e->getMessage()}")
+                ->danger()
+                ->send();
+            return null;
+        }
+    }
+
+    protected function tenantDb(): ?\Illuminate\Database\ConnectionInterface
+    {
+        if (! $this->tenantConnectionName) {
+            $this->connectToTenant();
+        }
+
+        if (! $this->tenantConnectionName) {
+            return null;
+        }
+
+        return DB::connection($this->tenantConnectionName);
+    }
+
+    protected function logConfigChange(string $action, string $description, array $metadata = []): void
+    {
+        $tenant = $this->getSelectedTenant();
+        if (! $tenant) {
+            return;
+        }
+
+        TenantActivityLog::log(
+            tenantId: $tenant->id,
+            action: $action,
+            description: $description,
+            performedByUserId: auth()->id(),
+            metadata: $metadata,
+        );
+    }
+
+    protected function closeTenantConnection(): void
+    {
+        if ($this->tenantConnectionName) {
+            DB::purge($this->tenantConnectionName);
+            $this->tenantConnectionName = null;
+        }
+    }
+}

--- a/app/Filament/Traits/TenantConfigTrait.php
+++ b/app/Filament/Traits/TenantConfigTrait.php
@@ -13,7 +13,16 @@ trait TenantConfigTrait
 {
     public ?int $selectedTenantId = null;
 
+    public array $tenants = [];
+
     protected ?string $tenantConnectionName = null;
+
+    protected ?Tenant $resolvedTenant = null;
+
+    public function mountTenantConfigTrait(): void
+    {
+        $this->tenants = $this->getActiveTenants();
+    }
 
     public function getActiveTenants(): array
     {
@@ -30,7 +39,16 @@ trait TenantConfigTrait
             return null;
         }
 
-        return Tenant::find($this->selectedTenantId);
+        return $this->resolvedTenant ??= Tenant::find($this->selectedTenantId);
+    }
+
+    protected function requireTenant(): bool
+    {
+        if (! $this->selectedTenantId) {
+            Notification::make()->title('Sélectionnez un tenant')->warning()->send();
+            return false;
+        }
+        return true;
     }
 
     protected function connectToTenant(): ?string
@@ -84,10 +102,16 @@ trait TenantConfigTrait
         );
     }
 
+    protected function resetTenantState(): void
+    {
+        $this->closeTenantConnection();
+        $this->resolvedTenant = null;
+    }
+
     protected function closeTenantConnection(): void
     {
         if ($this->tenantConnectionName) {
-            DB::purge($this->tenantConnectionName);
+            app(TenantConnectionManager::class)->closeConnection($this->tenantConnectionName);
             $this->tenantConnectionName = null;
         }
     }

--- a/config/klassci.php
+++ b/config/klassci.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Emails destinataires des alertes
+    |--------------------------------------------------------------------------
+    |
+    | Liste des adresses email qui recevront le récapitulatif quotidien des
+    | alertes (quota, expiration, santé, backups). Si vide, les emails des
+    | admins actifs seront utilisés en fallback.
+    |
+    */
+    'alert_emails' => array_filter(explode(',', env('KLASSCI_ALERT_EMAILS', ''))),
+
+];

--- a/resources/views/filament/pages/tenant-config/_tenant-selector.blade.php
+++ b/resources/views/filament/pages/tenant-config/_tenant-selector.blade.php
@@ -1,0 +1,17 @@
+{{-- Sélecteur de tenant (partagé par toutes les pages TenantConfig) --}}
+<div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+    <div class="flex items-center gap-4">
+        <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+            Établissement :
+        </label>
+        <select
+            wire:model.live="selectedTenantId"
+            class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        >
+            <option value="">— Sélectionner un tenant —</option>
+            @foreach ($tenants as $t)
+                <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
+            @endforeach
+        </select>
+    </div>
+</div>

--- a/resources/views/filament/pages/tenant-config/bulletin-style.blade.php
+++ b/resources/views/filament/pages/tenant-config/bulletin-style.blade.php
@@ -1,0 +1,116 @@
+<x-filament-panels::page>
+
+    {{-- Sélecteur de tenant --}}
+    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+        <div class="flex items-center gap-4">
+            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                Établissement :
+            </label>
+            <select
+                wire:model.live="selectedTenantId"
+                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+                <option value="">— Sélectionner un tenant —</option>
+                @foreach ($tenants as $t)
+                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    {{-- Contenu config --}}
+    @if ($selectedTenantId)
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-6">
+                Choix du style de bulletin PDF
+            </h3>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                {{-- Card Yakro --}}
+                <label
+                    class="relative cursor-pointer rounded-xl border-2 p-6 transition-all duration-200 hover:shadow-md
+                        {{ $bulletinStyle === 'yakro' ? 'border-primary-500 bg-primary-50 dark:bg-primary-950/20 ring-2 ring-primary-500/20' : 'border-gray-200 dark:border-gray-700 hover:border-gray-300' }}"
+                >
+                    <input type="radio" wire:model.live="bulletinStyle" value="yakro" class="sr-only" />
+                    <div class="flex items-start gap-4">
+                        <div class="flex-shrink-0 mt-1">
+                            <div class="w-5 h-5 rounded-full border-2 flex items-center justify-center
+                                {{ $bulletinStyle === 'yakro' ? 'border-primary-500 bg-primary-500' : 'border-gray-300 dark:border-gray-600' }}">
+                                @if ($bulletinStyle === 'yakro')
+                                    <svg class="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                                    </svg>
+                                @endif
+                            </div>
+                        </div>
+                        <div>
+                            <div class="text-base font-semibold text-gray-900 dark:text-white">Style Yakro</div>
+                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                Template classique avec en-tête institutionnel, colonnes matières alignées, cadre signature en bas de page.
+                            </p>
+                        </div>
+                    </div>
+                </label>
+
+                {{-- Card Abidjan --}}
+                <label
+                    class="relative cursor-pointer rounded-xl border-2 p-6 transition-all duration-200 hover:shadow-md
+                        {{ $bulletinStyle === 'abidjan' ? 'border-primary-500 bg-primary-50 dark:bg-primary-950/20 ring-2 ring-primary-500/20' : 'border-gray-200 dark:border-gray-700 hover:border-gray-300' }}"
+                >
+                    <input type="radio" wire:model.live="bulletinStyle" value="abidjan" class="sr-only" />
+                    <div class="flex items-start gap-4">
+                        <div class="flex-shrink-0 mt-1">
+                            <div class="w-5 h-5 rounded-full border-2 flex items-center justify-center
+                                {{ $bulletinStyle === 'abidjan' ? 'border-primary-500 bg-primary-500' : 'border-gray-300 dark:border-gray-600' }}">
+                                @if ($bulletinStyle === 'abidjan')
+                                    <svg class="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                                    </svg>
+                                @endif
+                            </div>
+                        </div>
+                        <div>
+                            <div class="text-base font-semibold text-gray-900 dark:text-white">Style Abidjan</div>
+                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                Template moderne avec logo centré, tableau de notes détaillé, statistiques de classe intégrées.
+                            </p>
+                        </div>
+                    </div>
+                </label>
+            </div>
+
+            {{-- Bouton sauvegarder --}}
+            <div class="flex justify-end">
+                <button
+                    wire:click="saveConfig"
+                    wire:loading.attr="disabled"
+                    class="fi-btn fi-btn-size-md relative inline-flex items-center justify-center gap-1.5 rounded-lg px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors duration-75 bg-primary-600 hover:bg-primary-500 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50"
+                >
+                    <span wire:loading.remove wire:target="saveConfig">
+                        <svg class="w-4 h-4 mr-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        Enregistrer
+                    </span>
+                    <span wire:loading wire:target="saveConfig">
+                        <svg class="w-4 h-4 mr-1 inline animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+                        </svg>
+                        Enregistrement...
+                    </span>
+                </button>
+            </div>
+        </div>
+    @else
+        {{-- État vide --}}
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-12 text-center">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+            </svg>
+            <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">Aucun tenant sélectionné</h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Sélectionnez un établissement pour configurer le style de bulletin.</p>
+        </div>
+    @endif
+
+</x-filament-panels::page>

--- a/resources/views/filament/pages/tenant-config/bulletin-style.blade.php
+++ b/resources/views/filament/pages/tenant-config/bulletin-style.blade.php
@@ -1,22 +1,6 @@
 <x-filament-panels::page>
 
-    {{-- Sélecteur de tenant --}}
-    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
-        <div class="flex items-center gap-4">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                Établissement :
-            </label>
-            <select
-                wire:model.live="selectedTenantId"
-                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-            >
-                <option value="">— Sélectionner un tenant —</option>
-                @foreach ($tenants as $t)
-                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
-                @endforeach
-            </select>
-        </div>
-    </div>
+    @include('filament.pages.tenant-config._tenant-selector')
 
     {{-- Contenu config --}}
     @if ($selectedTenantId)

--- a/resources/views/filament/pages/tenant-config/matricule-config.blade.php
+++ b/resources/views/filament/pages/tenant-config/matricule-config.blade.php
@@ -1,22 +1,6 @@
 <x-filament-panels::page>
 
-    {{-- Sélecteur de tenant --}}
-    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
-        <div class="flex items-center gap-4">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                Établissement :
-            </label>
-            <select
-                wire:model.live="selectedTenantId"
-                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-            >
-                <option value="">— Sélectionner un tenant —</option>
-                @foreach ($tenants as $t)
-                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
-                @endforeach
-            </select>
-        </div>
-    </div>
+    @include('filament.pages.tenant-config._tenant-selector')
 
     @if ($selectedTenantId)
         {{-- Tableau des configs existantes --}}

--- a/resources/views/filament/pages/tenant-config/matricule-config.blade.php
+++ b/resources/views/filament/pages/tenant-config/matricule-config.blade.php
@@ -1,0 +1,192 @@
+<x-filament-panels::page>
+
+    {{-- Sélecteur de tenant --}}
+    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+        <div class="flex items-center gap-4">
+            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                Établissement :
+            </label>
+            <select
+                wire:model.live="selectedTenantId"
+                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+                <option value="">— Sélectionner un tenant —</option>
+                @foreach ($tenants as $t)
+                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    @if ($selectedTenantId)
+        {{-- Tableau des configs existantes --}}
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+                    Configurations matricule ({{ count($configs) }})
+                </h3>
+                <button
+                    wire:click="openForm"
+                    class="fi-btn fi-btn-size-sm inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-semibold text-white bg-primary-600 hover:bg-primary-500 transition-colors"
+                >
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                    </svg>
+                    Ajouter
+                </button>
+            </div>
+
+            @if (count($configs) > 0)
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm text-left">
+                        <thead class="text-xs text-gray-500 uppercase bg-gray-50 dark:bg-gray-800 dark:text-gray-400">
+                            <tr>
+                                <th class="px-4 py-3 rounded-tl-lg">Niveau</th>
+                                <th class="px-4 py-3">Nom</th>
+                                <th class="px-4 py-3">Préfixe</th>
+                                <th class="px-4 py-3">Format année</th>
+                                <th class="px-4 py-3">Digits</th>
+                                <th class="px-4 py-3">Actif</th>
+                                <th class="px-4 py-3 rounded-tr-lg text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($configs as $config)
+                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                                    <td class="px-4 py-3 font-mono font-semibold text-gray-900 dark:text-white">{{ $config['niveau_etude_code'] }}</td>
+                                    <td class="px-4 py-3 text-gray-700 dark:text-gray-300">{{ $config['niveau_etude_name'] }}</td>
+                                    <td class="px-4 py-3 font-mono text-gray-500">{{ $config['prefixe'] ?? '—' }}</td>
+                                    <td class="px-4 py-3 text-gray-500">{{ $config['annee_format'] }} chiffres</td>
+                                    <td class="px-4 py-3 text-gray-500">{{ $config['numero_digits'] }}</td>
+                                    <td class="px-4 py-3">
+                                        @if ($config['is_active'] ?? false)
+                                            <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">Actif</span>
+                                        @else
+                                            <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-400">Inactif</span>
+                                        @endif
+                                    </td>
+                                    <td class="px-4 py-3 text-right">
+                                        <div class="flex items-center justify-end gap-2">
+                                            <button wire:click="openForm({{ $config['id'] }})" class="text-primary-600 hover:text-primary-500" title="Modifier">
+                                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                                                </svg>
+                                            </button>
+                                            <button wire:click="deleteConfig({{ $config['id'] }})" wire:confirm="Supprimer cette configuration ?" class="text-red-500 hover:text-red-400" title="Supprimer">
+                                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <p class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+                    Aucune configuration matricule pour ce tenant.
+                </p>
+            @endif
+        </div>
+
+        {{-- Formulaire create/edit --}}
+        @if ($showForm)
+            <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                    {{ $editingId ? 'Modifier la configuration' : 'Nouvelle configuration' }}
+                </h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                    {{-- Niveau code --}}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Code niveau *</label>
+                        <input type="text" wire:model="formNiveauCode" placeholder="ex: BTS, LICENCE"
+                            class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm" />
+                        @error('formNiveauCode') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+
+                    {{-- Niveau name --}}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Nom du niveau *</label>
+                        <input type="text" wire:model="formNiveauName" placeholder="ex: Brevet de Technicien Supérieur"
+                            class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm" />
+                        @error('formNiveauName') <p class="mt-1 text-xs text-red-500">{{ $message }}</p> @enderror
+                    </div>
+
+                    {{-- Préfixe --}}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Préfixe (optionnel)</label>
+                        <input type="text" wire:model="formPrefixe" placeholder="ex: L, M"
+                            class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm" />
+                    </div>
+
+                    {{-- Année format --}}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Format année *</label>
+                        <select wire:model="formAnneeFormat"
+                            class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+                            <option value="2">2 chiffres (ex: 26)</option>
+                            <option value="4">4 chiffres (ex: 2026)</option>
+                        </select>
+                    </div>
+
+                    {{-- Numéro digits --}}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Nombre de digits *</label>
+                        <select wire:model="formNumeroDigits"
+                            class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+                            @for ($i = 3; $i <= 6; $i++)
+                                <option value="{{ $i }}">{{ $i }} chiffres (ex: {{ str_pad('1', $i, '0', STR_PAD_LEFT) }})</option>
+                            @endfor
+                        </select>
+                    </div>
+
+                    {{-- Description --}}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
+                        <input type="text" wire:model="formDescription" placeholder="Description optionnelle"
+                            class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm" />
+                    </div>
+                </div>
+
+                {{-- Prévisualisation --}}
+                <div class="mb-6 p-4 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+                    <span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Aperçu matricule</span>
+                    <p class="mt-1 text-lg font-mono font-bold text-primary-600 dark:text-primary-400">
+                        {{ $this->generatePreview() }}
+                    </p>
+                </div>
+
+                {{-- Boutons --}}
+                <div class="flex justify-end gap-3">
+                    <button
+                        wire:click="resetForm"
+                        class="inline-flex items-center rounded-lg px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-700"
+                    >
+                        Annuler
+                    </button>
+                    <button
+                        wire:click="saveConfig"
+                        wire:loading.attr="disabled"
+                        class="fi-btn inline-flex items-center rounded-lg px-4 py-2 text-sm font-semibold text-white bg-primary-600 hover:bg-primary-500 disabled:opacity-50"
+                    >
+                        {{ $editingId ? 'Mettre à jour' : 'Créer' }}
+                    </button>
+                </div>
+            </div>
+        @endif
+
+    @else
+        {{-- État vide --}}
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-12 text-center">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"/>
+            </svg>
+            <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">Aucun tenant sélectionné</h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Sélectionnez un établissement pour configurer les matricules.</p>
+        </div>
+    @endif
+
+</x-filament-panels::page>

--- a/resources/views/filament/pages/tenant-config/role-permission.blade.php
+++ b/resources/views/filament/pages/tenant-config/role-permission.blade.php
@@ -1,22 +1,6 @@
 <x-filament-panels::page>
 
-    {{-- Sélecteur de tenant --}}
-    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
-        <div class="flex items-center gap-4">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                Établissement :
-            </label>
-            <select
-                wire:model.live="selectedTenantId"
-                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-            >
-                <option value="">— Sélectionner un tenant —</option>
-                @foreach ($tenants as $t)
-                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
-                @endforeach
-            </select>
-        </div>
-    </div>
+    @include('filament.pages.tenant-config._tenant-selector')
 
     @if ($selectedTenantId && count($roles) > 0)
         <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/resources/views/filament/pages/tenant-config/role-permission.blade.php
+++ b/resources/views/filament/pages/tenant-config/role-permission.blade.php
@@ -1,0 +1,139 @@
+<x-filament-panels::page>
+
+    {{-- Sélecteur de tenant --}}
+    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+        <div class="flex items-center gap-4">
+            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                Établissement :
+            </label>
+            <select
+                wire:model.live="selectedTenantId"
+                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+                <option value="">— Sélectionner un tenant —</option>
+                @foreach ($tenants as $t)
+                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    @if ($selectedTenantId && count($roles) > 0)
+        <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
+
+            {{-- Liste des rôles (sidebar gauche) --}}
+            <div class="lg:col-span-1">
+                <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-4">
+                    <h3 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">Rôles</h3>
+                    <nav class="space-y-1">
+                        @foreach ($roles as $role)
+                            <button
+                                wire:click="selectRole({{ $role['id'] }})"
+                                class="w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-sm font-medium transition-colors
+                                    {{ $selectedRoleId === $role['id']
+                                        ? 'bg-primary-50 text-primary-700 ring-1 ring-primary-200 dark:bg-primary-950/30 dark:text-primary-400 dark:ring-primary-800'
+                                        : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800' }}"
+                            >
+                                <span class="flex items-center gap-2">
+                                    <svg class="w-4 h-4 {{ $selectedRoleId === $role['id'] ? 'text-primary-500' : 'text-gray-400' }}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                                    </svg>
+                                    {{ ucfirst($role['name']) }}
+                                </span>
+                                @if ($selectedRoleId === $role['id'])
+                                    <span class="inline-flex items-center rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/50 dark:text-primary-300">
+                                        {{ count($rolePermissionIds) }}
+                                    </span>
+                                @endif
+                            </button>
+                        @endforeach
+                    </nav>
+                </div>
+            </div>
+
+            {{-- Grille des permissions (contenu principal) --}}
+            <div class="lg:col-span-3">
+                @if ($selectedRoleId)
+                    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6">
+                        <div class="flex items-center justify-between mb-6">
+                            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+                                Permissions de
+                                <span class="text-primary-600 dark:text-primary-400">{{ ucfirst($selectedRoleName) }}</span>
+                            </h3>
+                            <span class="text-sm text-gray-500 dark:text-gray-400">
+                                {{ count($rolePermissionIds) }} / {{ count($permissions) }} permissions
+                            </span>
+                        </div>
+
+                        @foreach ($groupedPermissions as $group => $perms)
+                            <div class="mb-6 last:mb-0">
+                                <h4 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3 pb-2 border-b border-gray-100 dark:border-gray-800">
+                                    {{ $group }} ({{ count($perms) }})
+                                </h4>
+                                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                                    @foreach ($perms as $perm)
+                                        <label
+                                            class="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-colors
+                                                {{ in_array($perm['id'], $rolePermissionIds)
+                                                    ? 'bg-primary-50/50 dark:bg-primary-950/10'
+                                                    : 'hover:bg-gray-50 dark:hover:bg-gray-800/50' }}"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                wire:click="togglePermission({{ $perm['id'] }})"
+                                                @checked(in_array($perm['id'], $rolePermissionIds))
+                                                class="rounded border-gray-300 text-primary-600 shadow-sm focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+                                            />
+                                            <span class="text-sm text-gray-700 dark:text-gray-300 truncate" title="{{ $perm['name'] }}">
+                                                {{ $perm['name'] }}
+                                            </span>
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endforeach
+
+                        {{-- Bouton sauvegarder --}}
+                        <div class="flex justify-end mt-6 pt-4 border-t border-gray-100 dark:border-gray-800">
+                            <button
+                                wire:click="savePermissions"
+                                wire:loading.attr="disabled"
+                                class="fi-btn inline-flex items-center gap-1.5 rounded-lg px-5 py-2.5 text-sm font-semibold text-white bg-primary-600 hover:bg-primary-500 shadow-sm transition-colors disabled:opacity-50"
+                            >
+                                <span wire:loading.remove wire:target="savePermissions">
+                                    <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+                                    </svg>
+                                    Enregistrer les permissions
+                                </span>
+                                <span wire:loading wire:target="savePermissions">Enregistrement...</span>
+                            </button>
+                        </div>
+                    </div>
+                @else
+                    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-12 text-center">
+                        <svg class="mx-auto h-10 w-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7"/>
+                        </svg>
+                        <h3 class="mt-3 text-sm font-medium text-gray-900 dark:text-white">Sélectionnez un rôle</h3>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Cliquez sur un rôle à gauche pour voir et modifier ses permissions.</p>
+                    </div>
+                @endif
+            </div>
+        </div>
+
+    @elseif ($selectedTenantId && count($roles) === 0)
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-8 text-center">
+            <p class="text-sm text-gray-500">Chargement des rôles...</p>
+        </div>
+    @else
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-12 text-center">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+            </svg>
+            <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">Aucun tenant sélectionné</h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Sélectionnez un établissement pour gérer les rôles et permissions.</p>
+        </div>
+    @endif
+
+</x-filament-panels::page>

--- a/resources/views/filament/pages/tenant-config/settings.blade.php
+++ b/resources/views/filament/pages/tenant-config/settings.blade.php
@@ -1,0 +1,140 @@
+<x-filament-panels::page>
+
+    {{-- Sélecteur de tenant --}}
+    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+        <div class="flex items-center gap-4">
+            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                Établissement :
+            </label>
+            <select
+                wire:model.live="selectedTenantId"
+                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+                <option value="">— Sélectionner un tenant —</option>
+                @foreach ($tenants as $t)
+                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    @if ($selectedTenantId && !empty($formValues))
+        @foreach ($this->getSettingGroups() as $groupKey => $group)
+            <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+                    <x-dynamic-component :component="$group['icon']" class="w-5 h-5 text-primary-500" />
+                    {{ $group['label'] }}
+                </h3>
+
+                @php
+                    $hasColors = collect($group['keys'])->contains(fn ($meta) => $meta['type'] === 'color');
+                    $hasBooleans = collect($group['keys'])->contains(fn ($meta) => $meta['type'] === 'boolean');
+                    $hasNumbers = collect($group['keys'])->contains(fn ($meta) => $meta['type'] === 'number');
+                @endphp
+
+                {{-- Color inputs --}}
+                @if ($hasColors)
+                    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+                        @foreach ($group['keys'] as $key => $meta)
+                            @if ($meta['type'] === 'color')
+                                <div>
+                                    <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">{{ $meta['label'] }}</label>
+                                    <div class="flex items-center gap-2">
+                                        <input
+                                            type="color"
+                                            wire:model="formValues.{{ $key }}"
+                                            class="h-10 w-14 rounded-lg border border-gray-300 dark:border-gray-600 cursor-pointer"
+                                        />
+                                        <input
+                                            type="text"
+                                            wire:model="formValues.{{ $key }}"
+                                            class="block w-full rounded-lg border-gray-300 shadow-sm text-xs font-mono focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                                            maxlength="7"
+                                        />
+                                    </div>
+                                </div>
+                            @endif
+                        @endforeach
+                    </div>
+                @endif
+
+                {{-- Boolean toggles --}}
+                @if ($hasBooleans)
+                    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+                        @foreach ($group['keys'] as $key => $meta)
+                            @if ($meta['type'] === 'boolean')
+                                <label class="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer transition-colors">
+                                    <input
+                                        type="checkbox"
+                                        wire:model="formValues.{{ $key }}"
+                                        value="1"
+                                        @checked(($formValues[$key] ?? '0') === '1' || ($formValues[$key] ?? '0') === 1 || ($formValues[$key] ?? false) === true)
+                                        class="rounded border-gray-300 text-primary-600 shadow-sm focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+                                    />
+                                    <span class="text-sm text-gray-700 dark:text-gray-300">{{ $meta['label'] }}</span>
+                                </label>
+                            @endif
+                        @endforeach
+                    </div>
+                @endif
+
+                {{-- Number inputs --}}
+                @if ($hasNumbers)
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                        @foreach ($group['keys'] as $key => $meta)
+                            @if ($meta['type'] === 'number')
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $meta['label'] }}</label>
+                                    <input
+                                        type="number"
+                                        wire:model="formValues.{{ $key }}"
+                                        min="0"
+                                        max="10"
+                                        step="1"
+                                        class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm"
+                                    />
+                                </div>
+                            @endif
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        @endforeach
+
+        {{-- Bouton sauvegarder --}}
+        <div class="flex justify-end">
+            <button
+                wire:click="saveSettings"
+                wire:loading.attr="disabled"
+                class="fi-btn inline-flex items-center gap-1.5 rounded-lg px-5 py-2.5 text-sm font-semibold text-white bg-primary-600 hover:bg-primary-500 shadow-sm transition-colors disabled:opacity-50"
+            >
+                <span wire:loading.remove wire:target="saveSettings">
+                    <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    Enregistrer tous les paramètres
+                </span>
+                <span wire:loading wire:target="saveSettings">Enregistrement...</span>
+            </button>
+        </div>
+
+    @elseif ($selectedTenantId && empty($formValues))
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-8 text-center">
+            <svg class="mx-auto h-8 w-8 text-gray-400 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+            </svg>
+            <p class="mt-3 text-sm text-gray-500">Chargement des paramètres...</p>
+        </div>
+    @else
+        <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-12 text-center">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+            </svg>
+            <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">Aucun tenant sélectionné</h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Sélectionnez un établissement pour voir ses paramètres PDF et bulletin.</p>
+        </div>
+    @endif
+
+</x-filament-panels::page>

--- a/resources/views/filament/pages/tenant-config/settings.blade.php
+++ b/resources/views/filament/pages/tenant-config/settings.blade.php
@@ -1,22 +1,6 @@
 <x-filament-panels::page>
 
-    {{-- Sélecteur de tenant --}}
-    <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-6 mb-6">
-        <div class="flex items-center gap-4">
-            <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                Établissement :
-            </label>
-            <select
-                wire:model.live="selectedTenantId"
-                class="fi-select-input block w-full max-w-md rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-            >
-                <option value="">— Sélectionner un tenant —</option>
-                @foreach ($tenants as $t)
-                    <option value="{{ $t['id'] }}">{{ $t['name'] }} ({{ $t['code'] }})</option>
-                @endforeach
-            </select>
-        </div>
-    </div>
+    @include('filament.pages.tenant-config._tenant-selector')
 
     @if ($selectedTenantId && !empty($formValues))
         @foreach ($this->getSettingGroups() as $groupKey => $group)


### PR DESCRIPTION
## Summary

- **4 pages Filament** pour configurer chaque tenant depuis le panneau admin SaaS :
  - Rôles & Permissions (Spatie sync + cache clear)
  - Config Matricule (CRUD format matricule par niveau)
  - Style Bulletin (radio yakro/abidjan)
  - Settings PDF (couleurs, checkboxes bulletin, poids semestres)
- **TenantConfigTrait** partagé : sélecteur tenant, connexion dynamique cross-DB, activity logging, guards
- **Email récapitulatif** des alertes dans `SendTenantAlerts` (quota, expiration, santé, backup)
- **SCHEDULER_ACTIVATION.md** : instructions cron pour production LWS

## Fichiers créés/modifiés

| Fichier | Action |
|---------|--------|
| `app/Filament/Traits/TenantConfigTrait.php` | Nouveau — trait partagé |
| `app/Filament/Pages/TenantConfig/*.php` | 4 nouvelles pages |
| `resources/views/filament/pages/tenant-config/*.blade.php` | 5 vues (4 pages + 1 partial) |
| `app/Console/Commands/SendTenantAlerts.php` | Modifié — ajout email recap |
| `config/klassci.php` | Nouveau — config alert_emails |
| `.env.example` | Modifié — ajout KLASSCI_ALERT_EMAILS |
| `SCHEDULER_ACTIVATION.md` | Nouveau — doc activation cron |

## Test plan

- [ ] Sélectionner un tenant → vérifier que les configs se chargent depuis sa BDD
- [ ] Modifier le style bulletin → vérifier persistance dans la table `settings` du tenant
- [ ] CRUD config matricule → créer, éditer, supprimer, vérifier preview
- [ ] Modifier settings PDF (couleurs, checkboxes) → vérifier bulk upsert
- [ ] Modifier permissions d'un rôle → vérifier sync dans `role_has_permissions`
- [ ] `php artisan tenant:send-alerts --dry-run` → vérifier email recap
- [ ] Vérifier qu'aucune connexion tenant ne fuit (logs de closeConnection)

Refs #159