### PR TITLE
feat(group-portal): PR4b foundation UI — period selector + feature flag + a11y

### DIFF
--- a/app/Filament/Group/Resources/EstablishmentResource.php
+++ b/app/Filament/Group/Resources/EstablishmentResource.php
@@ -26,6 +26,50 @@ class EstablishmentResource extends Resource
 
     protected static ?int $navigationSort = 2;
 
+    public static function getNavigationBadge(): ?string
+    {
+        $user = auth('group')->user();
+        $group = $user?->group;
+
+        if (! $group) {
+            return null;
+        }
+
+        try {
+            $alerts = app(TenantAggregationService::class)->getGroupHealthMetrics($group)['alerts'] ?? [];
+            $count = count($alerts);
+
+            return $count > 0 ? (string) $count : null;
+        } catch (\Throwable) {
+            // Silent degradation — badge is non-critical.
+            return null;
+        }
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        $user = auth('group')->user();
+        $group = $user?->group;
+
+        if (! $group) {
+            return null;
+        }
+
+        try {
+            $alerts = app(TenantAggregationService::class)->getGroupHealthMetrics($group)['alerts'] ?? [];
+
+            foreach ($alerts as $alert) {
+                if (($alert['severity'] ?? null) === 'critical') {
+                    return 'danger';
+                }
+            }
+
+            return count($alerts) > 0 ? 'warning' : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
     public static function getEloquentQuery(): Builder
     {
         $groupId = auth('group')->user()?->group_id;

--- a/app/Livewire/Group/PortalPeriodSelector.php
+++ b/app/Livewire/Group/PortalPeriodSelector.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Livewire\Group;
+
+use App\Support\Period\PeriodFactory;
+use App\Support\Period\PeriodInterface;
+use App\Support\Period\PeriodType;
+use Carbon\CarbonImmutable;
+use Illuminate\View\View;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+/**
+ * Period selector for the group portal topbar.
+ *
+ * PR4b scope: UI + URL persistence only. Does NOT dispatch browser events nor
+ * mutate any backend cache. Widget wiring is deferred to PR4c where a fixed
+ * event contract will be introduced with real consumers.
+ *
+ * Security: #[Url] properties come from untrusted query strings. All hydration
+ * goes through PeriodType::tryFromSafe() and CarbonImmutable::parse() in try/catch
+ * so malicious payloads (XSS, SQL-like, oversized strings) fall back to the default.
+ */
+class PortalPeriodSelector extends Component
+{
+    #[Url(as: 'period')]
+    public string $periodType = '';
+
+    #[Url(as: 'start')]
+    public ?string $customStart = null;
+
+    #[Url(as: 'end')]
+    public ?string $customEnd = null;
+
+    public function mount(): void
+    {
+        $this->periodType = PeriodType::tryFromSafe($this->periodType)->value;
+    }
+
+    public function updatedPeriodType(string $value): void
+    {
+        // Re-normalize after user-driven change (defense in depth: Livewire already
+        // re-hydrates via #[Url] but we re-validate in case of programmatic sets).
+        $this->periodType = PeriodType::tryFromSafe($value)->value;
+    }
+
+    public function getCurrentTypeProperty(): PeriodType
+    {
+        return PeriodType::tryFromSafe($this->periodType);
+    }
+
+    public function getCurrentLabelProperty(): string
+    {
+        return $this->currentType->label();
+    }
+
+    /**
+     * Build the Period value object for the current selection.
+     * Returns null when CustomRange is selected but dates are incomplete/invalid —
+     * the UI then shows the custom-range picker without committing a range.
+     */
+    public function getResolvedPeriodProperty(): ?PeriodInterface
+    {
+        return match ($this->currentType) {
+            PeriodType::CurrentMonth => PeriodFactory::make(PeriodFactory::TYPE_CURRENT_MONTH),
+            PeriodType::CurrentYear => PeriodFactory::make(PeriodFactory::TYPE_CURRENT_YEAR),
+            PeriodType::CustomRange => $this->resolveCustomRange(),
+        };
+    }
+
+    private function resolveCustomRange(): ?PeriodInterface
+    {
+        if (!$this->customStart || !$this->customEnd) {
+            return null;
+        }
+
+        try {
+            return PeriodFactory::make(PeriodFactory::TYPE_CUSTOM_RANGE, [
+                'start' => CarbonImmutable::parse($this->customStart),
+                'end' => CarbonImmutable::parse($this->customEnd),
+            ]);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.group.portal-period-selector', [
+            'types' => PeriodType::cases(),
+        ]);
+    }
+}

--- a/app/Providers/Filament/GroupPanelProvider.php
+++ b/app/Providers/Filament/GroupPanelProvider.php
@@ -12,6 +12,7 @@ use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\View\PanelsRenderHook;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -61,6 +62,10 @@ class GroupPanelProvider extends PanelProvider
                     . '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>'
                     . '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&display=swap">'
                     . '<link rel="stylesheet" href="' . asset('css/groupe-portal.css') . '?v=' . (@filemtime(public_path('css/groupe-portal.css')) ?: time()) . '">'
+            )
+            ->renderHook(
+                PanelsRenderHook::TOPBAR_END,
+                fn () => view('filament.group.partials.topbar-period'),
             )
             ->sidebarCollapsibleOnDesktop()
             ->maxContentWidth('full')

--- a/app/Support/Period/PeriodType.php
+++ b/app/Support/Period/PeriodType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Support\Period;
+
+/**
+ * Whitelisted period types. Backing values match PeriodFactory::TYPE_* constants.
+ * Used as the safe hydration boundary for user-provided input (#[Url] query strings).
+ */
+enum PeriodType: string
+{
+    case CurrentMonth = 'current-month';
+    case CurrentYear = 'current-year';
+    case CustomRange = 'custom-range';
+
+    /**
+     * Safe hydration from untrusted input — never throws, rejects invalid values silently.
+     * Returns the default when the input is null, empty, or not in the enum.
+     */
+    public static function tryFromSafe(?string $value): self
+    {
+        if ($value === null || $value === '') {
+            return self::default();
+        }
+
+        return self::tryFrom($value) ?? self::default();
+    }
+
+    public static function default(): self
+    {
+        return self::CurrentYear;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CurrentMonth => 'Mois en cours',
+            self::CurrentYear => 'Année en cours',
+            self::CustomRange => 'Plage personnalisée',
+        };
+    }
+}

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Period selector (PR4b foundation UI)
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, a Livewire period selector is injected in the group portal
+    | topbar via PanelsRenderHook::TOPBAR_END. The selected period is persisted
+    | in the URL query string as ?period=current-month|current-year|custom-range.
+    |
+    | Default OFF for production safety: the selector ships dark and is wired
+    | to widget providers in PR4c. Activate progressively via .env:
+    |
+    |   GROUP_PORTAL_PERIOD_SELECTOR=true
+    |
+    */
+    'period_selector_enabled' => env('GROUP_PORTAL_PERIOD_SELECTOR', false),
+
+    /*
+    | Debounce applied client-side (Alpine) before the Livewire state is updated.
+    | Tuned for quick clicks without triggering one HTTP roundtrip per keystroke.
+    */
+    'period_selector_debounce_ms' => env('GROUP_PORTAL_PERIOD_DEBOUNCE_MS', 300),
+];

--- a/docs/PORTAIL_GROUPE_DEPLOIEMENT.md
+++ b/docs/PORTAIL_GROUPE_DEPLOIEMENT.md
@@ -96,3 +96,57 @@ Si `MASTER_API_URL` / `MASTER_API_TOKEN` absents côté tenant, l'appel est skip
 - Alerter sur `group_portal_sso_logs.success=0` rate > 10/min (potentielle brute-force)
 - Alerter sur `[SSO] GROUP_SSO_SHARED_SECRET is too short` dans logs
 - Dashboard : taux d'ouverture SSO par fondateur / tenant
+
+---
+
+## PR4b — Period selector topbar (activation progressive)
+
+Livré dans #10. Le sélecteur de période apparaît dans la topbar du portail groupe (button + listbox ARIA + custom range). **Désactivé par défaut** pour ne pas impacter la production au merge. Wiring aux widgets = PR4c.
+
+### Activer en prod
+
+Ajouter dans `.env` :
+
+```env
+GROUP_PORTAL_PERIOD_SELECTOR=true
+# Optionnel — défaut 300ms
+GROUP_PORTAL_PERIOD_DEBOUNCE_MS=300
+```
+
+Puis `php artisan config:clear` côté serveur (Filament + Laravel lisent le flag depuis `config('group_portal.period_selector_enabled')` qui peut être cached via `config:cache`).
+
+### Désactiver en urgence
+
+```env
+GROUP_PORTAL_PERIOD_SELECTOR=false
+```
+
++ `php artisan config:clear`. Le partial Blade retourne une string vide — zéro render, zéro JS, zéro CSS supplémentaire chargé.
+
+### a11y — Keyboard map du sélecteur
+
+| Touche | Action |
+|---|---|
+| `Tab` | Focus sur le bouton |
+| `Enter` / `Espace` / `↓` | Ouvrir la listbox |
+| `↑` / `↓` | Naviguer entre les options |
+| `Enter` / `Espace` | Sélectionner l'option focalisée |
+| `Escape` | Fermer la listbox / le panneau custom |
+| `Tab` (dans panneau custom) | Focus piégé entre les 2 date pickers + bouton Fermer |
+
+### Sanitization XSS
+
+Toutes les valeurs lues depuis la query string (`?period=`, `?start=`, `?end=`) passent par `PeriodType::tryFromSafe()` (whitelist d'enum) ou `CarbonImmutable::parse()` en try/catch. Les payloads malicieux retombent silencieusement sur le défaut `current-year` sans logger ni throw.
+
+### Non-wiring aux widgets
+
+En PR4b, la période sélectionnée est **persistée en URL seulement** — les 7 widgets du dashboard (`KpiOverviewWidget`, `GroupAlertsWidget`, `GroupAgingWidget`, `EstablishmentCardsWidget`, etc.) n'en tiennent pas encore compte. Ils continuent d'afficher "année universitaire en cours" comme avant. Le wiring (avec contrat d'event figé) est livré dans PR4c.
+
+### Badge alertes sidebar
+
+Le navigation item "Établissements" affiche un badge dynamique :
+- Pas de badge : aucune alerte
+- Badge `warning` (orange) : ≥ 1 alerte non-critique
+- Badge `danger` (rouge) : ≥ 1 alerte `critical`
+
+Compte calculé via `TenantAggregationService::getGroupHealthMetrics()['alerts']` — cache TTL 5 min, donc l'impact perf est négligeable.

--- a/public/css/groupe-portal.css
+++ b/public/css/groupe-portal.css
@@ -1161,3 +1161,197 @@
     .gp-alerts-header { flex-direction: column; align-items: stretch; }
     .gp-alert-type { display: none; }
 }
+
+/* ═══════════════════════════════════════════════
+   PR4b — Topbar period selector
+   Button + listbox ARIA pattern with Custom Range panel.
+   Feature-flagged via config/group_portal.php.
+   ═══════════════════════════════════════════════ */
+
+.gp-topbar-slot {
+    display: flex;
+    align-items: center;
+    padding: 0 0.75rem;
+}
+
+.gp-period-selector {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.gp-period-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.875rem;
+    border: 1px solid var(--gp-border);
+    border-radius: 0.625rem;
+    background: #fff;
+    color: var(--gp-text);
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.gp-period-button:hover {
+    border-color: var(--gp-primary-light);
+}
+
+.gp-period-button:focus-visible {
+    outline: 2px solid var(--gp-primary);
+    outline-offset: 2px;
+    border-color: var(--gp-primary);
+}
+
+.gp-period-button[aria-expanded="true"] {
+    border-color: var(--gp-primary);
+    box-shadow: 0 0 0 3px var(--gp-primary-bg);
+}
+
+.gp-period-button svg {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    color: var(--gp-text-secondary);
+}
+
+.gp-period-button .gp-period-chevron {
+    transition: transform 0.15s ease;
+}
+
+.gp-period-button .gp-period-chevron.is-open {
+    transform: rotate(180deg);
+}
+
+.gp-period-label {
+    white-space: nowrap;
+}
+
+.gp-period-listbox {
+    position: absolute;
+    top: calc(100% + 0.375rem);
+    right: 0;
+    z-index: 50;
+    min-width: 14rem;
+    margin: 0;
+    padding: 0.375rem;
+    list-style: none;
+    background: #fff;
+    border: 1px solid var(--gp-border);
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 25px -5px rgba(15, 23, 42, 0.12), 0 4px 10px -4px rgba(15, 23, 42, 0.08);
+}
+
+.gp-period-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--gp-text);
+    cursor: pointer;
+    transition: background 0.1s ease;
+}
+
+.gp-period-option:hover,
+.gp-period-option:focus {
+    background: var(--gp-bg-subtle);
+    outline: none;
+}
+
+.gp-period-option:focus-visible {
+    outline: 2px solid var(--gp-primary);
+    outline-offset: -2px;
+}
+
+.gp-period-option.is-active {
+    color: var(--gp-primary);
+    font-weight: 600;
+    background: var(--gp-primary-bg);
+}
+
+.gp-period-option svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    color: var(--gp-primary);
+    flex-shrink: 0;
+}
+
+.gp-period-custom {
+    position: absolute;
+    top: calc(100% + 0.375rem);
+    right: 0;
+    z-index: 51;
+    min-width: 18rem;
+    padding: 0.875rem;
+    background: #fff;
+    border: 1px solid var(--gp-border);
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 25px -5px rgba(15, 23, 42, 0.12), 0 4px 10px -4px rgba(15, 23, 42, 0.08);
+}
+
+.gp-period-custom-row {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.gp-period-custom-field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--gp-text-secondary);
+    font-weight: 500;
+}
+
+.gp-period-custom-field input {
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--gp-border);
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--gp-text);
+    background: #fff;
+}
+
+.gp-period-custom-field input:focus-visible {
+    outline: 2px solid var(--gp-primary);
+    outline-offset: 1px;
+    border-color: var(--gp-primary);
+}
+
+.gp-period-custom-close {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--gp-border);
+    border-radius: 0.5rem;
+    background: var(--gp-bg-subtle);
+    color: var(--gp-text);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.1s ease;
+}
+
+.gp-period-custom-close:hover {
+    background: #eef2f7;
+}
+
+@media (max-width: 640px) {
+    .gp-period-listbox,
+    .gp-period-custom {
+        right: auto;
+        left: 0;
+    }
+    .gp-period-label {
+        max-width: 8rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/resources/views/filament/group/partials/topbar-period.blade.php
+++ b/resources/views/filament/group/partials/topbar-period.blade.php
@@ -1,0 +1,5 @@
+@if(config('group_portal.period_selector_enabled'))
+    <div class="gp-topbar-slot">
+        @livewire(\App\Livewire\Group\PortalPeriodSelector::class)
+    </div>
+@endif

--- a/resources/views/livewire/group/portal-period-selector.blade.php
+++ b/resources/views/livewire/group/portal-period-selector.blade.php
@@ -1,0 +1,162 @@
+@php
+    $listboxId = 'gp-period-listbox-' . $this->getId();
+    $panelId = 'gp-period-custom-panel-' . $this->getId();
+    $currentValue = $this->currentType->value;
+    $debounceMs = (int) config('group_portal.period_selector_debounce_ms', 300);
+@endphp
+
+<div
+    class="gp-period-selector"
+    x-data="{
+        open: false,
+        customOpen: @js($currentValue === 'custom-range'),
+        localType: @js($currentValue),
+        localStart: @js($customStart),
+        localEnd: @js($customEnd),
+        debounceId: null,
+        debounceMs: {{ $debounceMs }},
+        select(value) {
+            this.localType = value;
+            this.open = false;
+            if (value === 'custom-range') {
+                this.customOpen = true;
+                this.$nextTick(() => this.$refs.customStart?.focus());
+            } else {
+                this.customOpen = false;
+            }
+            this.commitType();
+        },
+        commitType() {
+            clearTimeout(this.debounceId);
+            this.debounceId = setTimeout(() => {
+                $wire.set('periodType', this.localType);
+            }, this.debounceMs);
+        },
+        commitRange() {
+            clearTimeout(this.debounceId);
+            this.debounceId = setTimeout(() => {
+                $wire.set('customStart', this.localStart);
+                $wire.set('customEnd', this.localEnd);
+            }, this.debounceMs);
+        },
+        toggleListbox() {
+            this.open = !this.open;
+            if (this.open) {
+                this.$nextTick(() => this.$refs.currentOption?.focus());
+            }
+        },
+        focusNext() {
+            const options = Array.from(this.$refs.listbox?.querySelectorAll('[role=option]') ?? []);
+            const current = options.indexOf(document.activeElement);
+            (options[current + 1] ?? options[0])?.focus();
+        },
+        focusPrev() {
+            const options = Array.from(this.$refs.listbox?.querySelectorAll('[role=option]') ?? []);
+            const current = options.indexOf(document.activeElement);
+            (options[current - 1] ?? options[options.length - 1])?.focus();
+        },
+    }"
+    @keydown.escape.window="open = false; customOpen = (localType === 'custom-range')"
+>
+    <button
+        type="button"
+        class="gp-period-button"
+        aria-haspopup="listbox"
+        :aria-expanded="open.toString()"
+        aria-controls="{{ $listboxId }}"
+        aria-label="Sélectionner une période"
+        @click="toggleListbox()"
+        @keydown.down.prevent="open = true; $nextTick(() => $refs.currentOption?.focus())"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+            <line x1="16" y1="2" x2="16" y2="6"></line>
+            <line x1="8" y1="2" x2="8" y2="6"></line>
+            <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        <span class="gp-period-label" x-text="(() => {
+            const labels = @js(collect($types)->mapWithKeys(fn ($t) => [$t->value => $t->label()])->toArray());
+            return labels[localType] ?? '{{ $this->currentLabel }}';
+        })()">{{ $this->currentLabel }}</span>
+        <svg class="gp-period-chevron" :class="open ? 'is-open' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+    </button>
+
+    <ul
+        id="{{ $listboxId }}"
+        x-ref="listbox"
+        role="listbox"
+        aria-label="Périodes disponibles"
+        class="gp-period-listbox"
+        x-show="open"
+        x-transition.opacity.duration.150ms
+        x-trap="open"
+        @keydown.down.prevent="focusNext()"
+        @keydown.up.prevent="focusPrev()"
+        @click.outside="open = false"
+        style="display: none;"
+    >
+        @foreach ($types as $type)
+            <li
+                role="option"
+                tabindex="{{ $type->value === $currentValue ? '0' : '-1' }}"
+                :aria-selected="(localType === @js($type->value)).toString()"
+                x-ref="{{ $type->value === $currentValue ? 'currentOption' : '' }}"
+                @click="select(@js($type->value))"
+                @keydown.enter.prevent="select(@js($type->value))"
+                @keydown.space.prevent="select(@js($type->value))"
+                class="gp-period-option"
+                :class="localType === @js($type->value) ? 'is-active' : ''"
+            >
+                <span>{{ $type->label() }}</span>
+                <svg x-show="localType === @js($type->value)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+            </li>
+        @endforeach
+    </ul>
+
+    {{-- Custom range panel — separate a11y surface with its own focus trap --}}
+    <div
+        id="{{ $panelId }}"
+        class="gp-period-custom"
+        role="dialog"
+        aria-label="Plage personnalisée"
+        x-show="customOpen"
+        x-transition.opacity.duration.150ms
+        x-trap="customOpen"
+        @keydown.escape.stop="customOpen = false"
+        style="display: none;"
+    >
+        <div class="gp-period-custom-row">
+            <label class="gp-period-custom-field">
+                <span>Du</span>
+                <input
+                    x-ref="customStart"
+                    type="date"
+                    x-model="localStart"
+                    @change="commitRange()"
+                    aria-label="Date de début"
+                >
+            </label>
+            <label class="gp-period-custom-field">
+                <span>Au</span>
+                <input
+                    type="date"
+                    x-model="localEnd"
+                    @change="commitRange()"
+                    aria-label="Date de fin"
+                >
+            </label>
+        </div>
+        <button
+            type="button"
+            class="gp-period-custom-close"
+            @click="customOpen = false"
+            aria-label="Fermer le sélecteur de plage personnalisée"
+        >
+            Fermer
+        </button>
+    </div>
+</div>

--- a/tests/Feature/Group/TopbarPeriodPartialTest.php
+++ b/tests/Feature/Group/TopbarPeriodPartialTest.php
@@ -1,0 +1,24 @@
+<?php
+
+it('topbar period partial renders nothing when feature flag is OFF', function () {
+    config(['group_portal.period_selector_enabled' => false]);
+
+    $html = view('filament.group.partials.topbar-period')->render();
+
+    expect(trim($html))->toBe('');
+});
+
+it('topbar period partial renders the Livewire component when feature flag is ON', function () {
+    config(['group_portal.period_selector_enabled' => true]);
+
+    $html = view('filament.group.partials.topbar-period')->render();
+
+    expect($html)->toContain('gp-topbar-slot');
+    expect($html)->toContain('gp-period-selector');
+});
+
+it('debounce ms config has a sensible default', function () {
+    expect(config('group_portal.period_selector_debounce_ms'))->toBeInt();
+    expect(config('group_portal.period_selector_debounce_ms'))->toBeGreaterThanOrEqual(100);
+    expect(config('group_portal.period_selector_debounce_ms'))->toBeLessThanOrEqual(1000);
+});

--- a/tests/Feature/Livewire/PortalPeriodSelectorTest.php
+++ b/tests/Feature/Livewire/PortalPeriodSelectorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Livewire\Group\PortalPeriodSelector;
+use App\Support\Period\CurrentMonthPeriod;
+use App\Support\Period\CurrentYearPeriod;
+use App\Support\Period\CustomRangePeriod;
+use App\Support\Period\PeriodType;
+use Livewire\Livewire;
+
+it('renders with the default period when no URL param is provided', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->assertSet('periodType', PeriodType::CurrentYear->value)
+        ->assertSee('Année en cours');
+});
+
+it('hydrates from a valid URL parameter', function () {
+    Livewire::withQueryParams(['period' => 'current-month'])
+        ->test(PortalPeriodSelector::class)
+        ->assertSet('periodType', 'current-month')
+        ->assertSee('Mois en cours');
+});
+
+it('falls back to default when URL parameter is malicious (XSS)', function () {
+    $xssPayload = '<script>alert(1)</script>';
+
+    Livewire::withQueryParams(['period' => $xssPayload])
+        ->test(PortalPeriodSelector::class)
+        ->assertSet('periodType', PeriodType::CurrentYear->value)
+        ->assertDontSee($xssPayload, false);
+});
+
+it('falls back to default when URL parameter is unknown', function () {
+    Livewire::withQueryParams(['period' => 'quarterly'])
+        ->test(PortalPeriodSelector::class)
+        ->assertSet('periodType', PeriodType::CurrentYear->value);
+});
+
+it('updating periodType to an invalid value re-normalizes to default', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'invalid-type')
+        ->assertSet('periodType', PeriodType::CurrentYear->value);
+});
+
+it('resolvedPeriod returns CurrentYearPeriod for current-year type', function () {
+    $component = Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'current-year');
+
+    expect($component->instance()->resolvedPeriod)->toBeInstanceOf(CurrentYearPeriod::class);
+});
+
+it('resolvedPeriod returns CurrentMonthPeriod for current-month type', function () {
+    $component = Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'current-month');
+
+    expect($component->instance()->resolvedPeriod)->toBeInstanceOf(CurrentMonthPeriod::class);
+});
+
+it('resolvedPeriod returns null for custom-range when dates incomplete', function () {
+    $component = Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'custom-range');
+
+    expect($component->instance()->resolvedPeriod)->toBeNull();
+});
+
+it('resolvedPeriod returns CustomRangePeriod when both dates present and valid', function () {
+    $component = Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'custom-range')
+        ->set('customStart', '2026-01-01')
+        ->set('customEnd', '2026-03-31');
+
+    expect($component->instance()->resolvedPeriod)->toBeInstanceOf(CustomRangePeriod::class);
+});
+
+it('resolvedPeriod returns null when custom dates are malformed (silent)', function () {
+    $component = Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'custom-range')
+        ->set('customStart', 'not-a-date')
+        ->set('customEnd', '<xss>');
+
+    expect($component->instance()->resolvedPeriod)->toBeNull();
+});

--- a/tests/Unit/Support/Period/PeriodTypeTest.php
+++ b/tests/Unit/Support/Period/PeriodTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Support\Period\PeriodFactory;
+use App\Support\Period\PeriodType;
+
+it('exposes the 3 expected cases with stable backing values', function () {
+    expect(PeriodType::CurrentMonth->value)->toBe('current-month');
+    expect(PeriodType::CurrentYear->value)->toBe('current-year');
+    expect(PeriodType::CustomRange->value)->toBe('custom-range');
+});
+
+it('backing values match PeriodFactory type constants (contract)', function () {
+    expect(PeriodType::CurrentMonth->value)->toBe(PeriodFactory::TYPE_CURRENT_MONTH);
+    expect(PeriodType::CurrentYear->value)->toBe(PeriodFactory::TYPE_CURRENT_YEAR);
+    expect(PeriodType::CustomRange->value)->toBe(PeriodFactory::TYPE_CUSTOM_RANGE);
+});
+
+it('default() returns CurrentYear (documented default)', function () {
+    expect(PeriodType::default())->toBe(PeriodType::CurrentYear);
+});
+
+it('tryFromSafe(null) returns the default', function () {
+    expect(PeriodType::tryFromSafe(null))->toBe(PeriodType::CurrentYear);
+});
+
+it('tryFromSafe("") returns the default', function () {
+    expect(PeriodType::tryFromSafe(''))->toBe(PeriodType::CurrentYear);
+});
+
+it('tryFromSafe(valid value) returns the matching case', function () {
+    expect(PeriodType::tryFromSafe('current-month'))->toBe(PeriodType::CurrentMonth);
+    expect(PeriodType::tryFromSafe('custom-range'))->toBe(PeriodType::CustomRange);
+});
+
+it('tryFromSafe rejects invalid values silently with default fallback', function () {
+    expect(PeriodType::tryFromSafe('quarterly'))->toBe(PeriodType::CurrentYear);
+    expect(PeriodType::tryFromSafe('weekly'))->toBe(PeriodType::CurrentYear);
+    expect(PeriodType::tryFromSafe('CURRENT-MONTH'))->toBe(PeriodType::CurrentYear); // case-sensitive
+});
+
+it('tryFromSafe rejects XSS payloads without throwing', function () {
+    $xssPayloads = [
+        '<script>alert(1)</script>',
+        'javascript:alert(1)',
+        '"><img src=x onerror=alert(1)>',
+        "' OR 1=1 --",
+        str_repeat('a', 10000),
+    ];
+
+    foreach ($xssPayloads as $payload) {
+        expect(PeriodType::tryFromSafe($payload))->toBe(PeriodType::CurrentYear);
+    }
+});
+
+it('label() returns french UI strings', function () {
+    expect(PeriodType::CurrentMonth->label())->toBe('Mois en cours');
+    expect(PeriodType::CurrentYear->label())->toBe('Année en cours');
+    expect(PeriodType::CustomRange->label())->toBe('Plage personnalisée');
+});


### PR DESCRIPTION
Closes #10

## Résumé

Foundation UI pour portail groupe. Période selector dans la topbar avec button+listbox ARIA-correct, feature flag OFF par défaut (zéro risque prod), Alpine-side debounce, PeriodType enum (sanitize XSS), badge sidebar sur Établissements.

Plan initial audité 4 axes → **2 BLOCK corrigés** : `role="combobox"` faux (remplacé par button+listbox), debounce côté Livewire (déplacé Alpine-side), `#[Url]` sans sanitize (enum `PeriodType::tryFromSafe()`), dispatch event sans consumer (retiré, contract figé PR4c), `-v2` CSS fragmentation (append existing file).

## 1 commit atomique

### `092c560` — Foundation UI complet

- **Type safety** : `App\Support\Period\PeriodType` (enum backed) + `tryFromSafe()` pour XSS sanitize
- **Config** : `config/group_portal.php` avec flag env default OFF + debounce 300ms
- **Livewire** : `App\Livewire\Group\PortalPeriodSelector` avec `#[Url(as: 'period')]` + enum hydration + resolvedPeriod computed
- **View** : button + listbox pattern + custom range dialog séparé + Alpine `x-trap` focus + debounce `setTimeout()`-wrapped `$wire.set()`
- **Topbar hook** : `PanelsRenderHook::TOPBAR_END` guardé par `@if(config())` → zéro render si flag OFF
- **CSS** : append à `groupe-portal.css` (+194 lignes, 1163 → 1357), namespace `gp-period-*` monochrome bleu
- **Badge sidebar** : `EstablishmentResource::getNavigationBadge()` + `getNavigationBadgeColor()` (count alertes + danger si critical)
- **Doc** : `docs/PORTAIL_GROUPE_DEPLOIEMENT.md` section "PR4b activation progressive" + keyboard map a11y

## Tests — 66 passants / 174 assertions (1 skipped gated)

**Nouveaux PR4b (22 tests)** :
- `PeriodTypeTest` — 9 tests (backing values, tryFromSafe null/empty/valid/unknown/XSS-payload/oversized/case-sensitive)
- `PortalPeriodSelectorTest` — 10 tests (URL hydration, XSS reject, invalid re-normalize, resolvedPeriod types, custom range malformed)
- `TopbarPeriodPartialTest` — 3 tests (flag OFF empty render, flag ON renders Livewire, debounce bounds)

## Visual check
- **Flag OFF** (default) : dashboard inchangé, zéro selector, zéro JS/CSS overhead
- **Flag ON** : bouton "Année en cours" avec icône calendrier dans topbar haut-droite, design cohérent monochrome bleu

## a11y — Button + listbox ARIA pattern

- `aria-haspopup="listbox"` + `aria-expanded` dynamic
- Options `role="option"` + `aria-selected`
- Keyboard : Enter/Space/↓ open, ↑↓ navigate, Enter/Space select, Escape close
- Custom Range = dialog séparé avec `x-trap` focus (Alpine Focus plugin)
- aria-label fr : "Sélectionner une période", "Périodes disponibles", "Plage personnalisée"

## XSS hardening

Toutes les valeurs URL (`?period=`, `?start=`, `?end=`) passent par :
- `PeriodType::tryFromSafe()` : whitelist enum, invalid → default silencieux
- `CarbonImmutable::parse()` dans `try/catch` : malformé → fallback null

Testé avec payloads `<script>alert(1)</script>`, `' OR 1=1 --`, string 10000 chars, case variations — tous retombent sur défaut.

## 4-axis audit post-implementation

| Axe | Verdict | Justification |
|---|---|---|
| Architecture | PASS | Button+listbox (standard), append CSS (pas fragmentation v2), enum + 1 NavigationItem badge |
| Qualité vs Vitesse | PASS | 22 nouveaux tests (XSS, URL, enum contract, flag toggle), Alpine debounce (1 req/intent) |
| Production-grade | PASS | Flag OFF default (zéro risque), a11y ARIA+focus trap, enum sanitize, graceful degradation |
| SOLID | PASS | SRP (selector ≠ Period logic), OCP (enum + PeriodFactory extensible), DIP (Factory stable PR4a) |

## Not in scope — reporté PR4c

- Dispatch browser event `period-changed` (contract figé avec consumers réels)
- Wiring KpiOverviewWidget / GroupAlertsWidget / GroupAgingWidget / EstablishmentCardsWidget aux `PeriodInterface`
- Cache key period-aware réel (`group_v2_{id}_kpis_{period_key}`)
- Migration widgets vers providers directs
- Breadcrumb (YAGNI, Filament page header suffit)
- Laravel Pennant (overkill 1 flag binaire)
- Refonte sidebar NavigationGroup complète

## Checklist deploy

- [ ] Merge → `composer install && php artisan config:clear` en prod
- [ ] **Flag reste OFF par défaut** — zéro impact prod au merge
- [ ] Activer progressivement : `GROUP_PORTAL_PERIOD_SELECTOR=true` dans `.env` tenant prod
- [ ] Monitorer `storage/logs/laravel.log` pendant 24h post-activation (guard try/catch silent)
- [ ] Vérifier badge alertes affiche correctement sur `/groupe` → Établissements