### PR TITLE
feat(group-portal): PR4c event contract — PeriodEventContract + dispatch

### DIFF
--- a/app/Livewire/Group/PortalPeriodSelector.php
+++ b/app/Livewire/Group/PortalPeriodSelector.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Group;
 
+use App\Support\Period\PeriodEventContract;
 use App\Support\Period\PeriodFactory;
 use App\Support\Period\PeriodInterface;
 use App\Support\Period\PeriodType;
@@ -42,6 +43,43 @@ class PortalPeriodSelector extends Component
         // Re-normalize after user-driven change (defense in depth: Livewire already
         // re-hydrates via #[Url] but we re-validate in case of programmatic sets).
         $this->periodType = PeriodType::tryFromSafe($value)->value;
+
+        $this->dispatchPeriodChange();
+    }
+
+    public function updatedCustomStart(): void
+    {
+        $this->dispatchPeriodChange();
+    }
+
+    public function updatedCustomEnd(): void
+    {
+        $this->dispatchPeriodChange();
+    }
+
+    /**
+     * Dispatches the frozen period-change event (see PeriodEventContract).
+     * Silently skipped when the current selection doesn't resolve to a Period
+     * (e.g. custom-range with missing/malformed dates) — the UI remains open
+     * without committing an ambiguous range to consumers.
+     */
+    private function dispatchPeriodChange(): void
+    {
+        $period = $this->resolvedPeriod;
+
+        if ($period === null) {
+            return;
+        }
+
+        // Livewire 3 sends named args as event.detail keys — consumers read
+        // $event.detail.type, .start, .end, .label on the browser side.
+        $this->dispatch(
+            PeriodEventContract::EVENT_NAME,
+            type: $this->currentType->value,
+            start: $period->startDate()->toIso8601String(),
+            end: $period->endDate()->toIso8601String(),
+            label: $period->label(),
+        );
     }
 
     public function getCurrentTypeProperty(): PeriodType
@@ -66,6 +104,60 @@ class PortalPeriodSelector extends Component
             PeriodType::CurrentYear => PeriodFactory::make(PeriodFactory::TYPE_CURRENT_YEAR),
             PeriodType::CustomRange => $this->resolveCustomRange(),
         };
+    }
+
+    /**
+     * The payload to broadcast as `PeriodEventContract::EVENT_NAME` — consumed by:
+     *   1. PHP `$this->dispatch()` in the lifecycle hooks above (Livewire bus)
+     *   2. Alpine `commit*()` helpers in the blade view, which re-emit as a true
+     *      browser CustomEvent on `window` (belt-and-braces: Livewire 3.x doesn't
+     *      always bubble the event to `window.dispatchEvent` depending on version
+     *      and event-name shape — colons in the name are sensitive).
+     *
+     * Returns null when the current selection has no resolvable period
+     * (e.g. custom-range with missing dates). Consumers treat null as "no-op".
+     *
+     * @return array{type: string, start: string, end: string, label: string}|null
+     */
+    public function getResolvedPayloadProperty(): ?array
+    {
+        $period = $this->resolvedPeriod;
+
+        if ($period === null) {
+            return null;
+        }
+
+        return [
+            'type' => $this->currentType->value,
+            'start' => $period->startDate()->toIso8601String(),
+            'end' => $period->endDate()->toIso8601String(),
+            'label' => $period->label(),
+        ];
+    }
+
+    /**
+     * Pre-computed payloads for the preset period types (CurrentMonth, CurrentYear).
+     * Injected as JSON into the blade so Alpine can dispatch without a server roundtrip.
+     * CustomRange payloads are built client-side from user-entered dates (labels are
+     * best-effort in JS — the server echo refreshes on Livewire re-render afterwards).
+     *
+     * @return array<string, array{type: string, start: string, end: string, label: string}>
+     */
+    public function getPresetPayloadsProperty(): array
+    {
+        $presets = [];
+
+        foreach ([PeriodType::CurrentMonth, PeriodType::CurrentYear] as $type) {
+            $period = PeriodFactory::make($type->value);
+            $presets[$type->value] = [
+                'type' => $type->value,
+                'start' => $period->startDate()->toIso8601String(),
+                'end' => $period->endDate()->toIso8601String(),
+                'label' => $period->label(),
+            ];
+        }
+
+        return $presets;
     }
 
     private function resolveCustomRange(): ?PeriodInterface

--- a/app/Support/Period/PeriodEventContract.php
+++ b/app/Support/Period/PeriodEventContract.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support\Period;
+
+/**
+ * Frozen contract for the group portal period-change event.
+ *
+ * ## Event name
+ *
+ * Namespaced to avoid collisions with other packages / Livewire-internal events:
+ *
+ *     klassci:group-portal:period-change
+ *
+ * ## Payload
+ *
+ * Minimal by design — no backend internals leak to consumers.
+ *
+ *     {
+ *         "type":  "current-year" | "current-month" | "custom-range",
+ *         "start": "2026-01-01T00:00:00+00:00",   // ISO 8601 (CarbonImmutable::toIso8601String)
+ *         "end":   "2026-12-31T23:59:59+00:00",   // ISO 8601
+ *         "label": "Année 2026"                    // human-readable, fr_FR, from PeriodInterface::label()
+ *     }
+ *
+ * `cacheKey` is deliberately OMITTED (backend derives it server-side from
+ * the Period value object — consumers must never reconstruct it).
+ *
+ * ## How to subscribe (Livewire widget)
+ *
+ *     <div x-data
+ *          @klassci:group-portal:period-change.window="$wire.onPeriodChanged($event.detail)"
+ *     >
+ *         {{-- widget content --}}
+ *     </div>
+ *
+ *     // PHP
+ *     public function onPeriodChanged(array $payload): void
+ *     {
+ *         $type  = $payload['type']  ?? null;
+ *         $start = $payload['start'] ?? null;
+ *         $end   = $payload['end']   ?? null;
+ *         // Always validate with PeriodType::tryFromSafe + CarbonImmutable::parse in try/catch.
+ *     }
+ *
+ * ## Invariants
+ *
+ * - The event is dispatched ONLY when the feature flag
+ *   `group_portal.period_selector_enabled` is ON (if the selector doesn't render,
+ *   it doesn't dispatch).
+ * - No dispatch when the user picks `custom-range` but the dates are incomplete
+ *   or unparseable — the UI shows the picker without committing.
+ * - `start` is always <= `end`; single-day ranges are legal (start == end).
+ *
+ * @see \App\Livewire\Group\PortalPeriodSelector — producer
+ * @see \App\Support\Period\PeriodInterface — backend value object (start/end/label)
+ * @see docs/GROUP_PORTAL_EVENT_CONTRACT.md — full spec + subscriber examples
+ */
+final class PeriodEventContract
+{
+    public const EVENT_NAME = 'klassci:group-portal:period-change';
+
+    /**
+     * Ordered list of required keys in the payload. Consumers can rely on all
+     * keys being present — defensive `?? null` on reads is still encouraged.
+     *
+     * @var list<string>
+     */
+    public const PAYLOAD_KEYS = ['type', 'start', 'end', 'label'];
+}

--- a/docs/GROUP_PORTAL_EVENT_CONTRACT.md
+++ b/docs/GROUP_PORTAL_EVENT_CONTRACT.md
@@ -1,0 +1,148 @@
+# Group Portal — Event Contract
+
+Public, frozen contract for the period-change event emitted by the group portal.
+
+**Consumers MUST read this doc** before subscribing; the shape is part of the public API and will be versioned if breaking changes are required.
+
+---
+
+## Single source of truth
+
+The event contract is defined as PHP constants in:
+
+    app/Support/Period/PeriodEventContract.php
+
+Any code path that dispatches or listens MUST import those constants — no magic strings.
+
+## Event name
+
+    klassci:group-portal:period-change
+
+Namespaced to avoid collisions with Livewire-internal events and other Filament plugins.
+
+## Payload
+
+Livewire 3 dispatches named arguments as `event.detail` keys:
+
+```json
+{
+  "type":  "current-year",
+  "start": "2026-01-01T00:00:00+00:00",
+  "end":   "2026-12-31T23:59:59+00:00",
+  "label": "Année 2026"
+}
+```
+
+### Fields
+
+| Key     | Type                   | Notes |
+|---------|------------------------|-------|
+| `type`  | `'current-month' \| 'current-year' \| 'custom-range'` | Matches `PeriodType` enum backing values |
+| `start` | ISO 8601 string        | `CarbonImmutable::toIso8601String()` — always `<= end`, always at `00:00:00` when normalized |
+| `end`   | ISO 8601 string        | Always `>= start`, at `23:59:59` when normalized |
+| `label` | string (French)        | Human-readable, from `PeriodInterface::label()` — safe to render directly in UI |
+
+### NOT in the payload
+
+- **`cacheKey`** — backend implementation detail. Consumers MUST NOT reconstruct cache keys; call the server-side provider with a `PeriodInterface` instance and let it derive the key.
+- **`timezone`** — always normalized through `CarbonImmutable`, same convention throughout the app.
+
+## When is it dispatched
+
+The selector dispatches ONLY when:
+
+1. Feature flag is ON: `config('group_portal.period_selector_enabled')` — if OFF, the selector doesn't render at all.
+2. The resolved `PeriodInterface` is non-null — custom-range with missing or unparseable dates does NOT dispatch.
+3. A Livewire lifecycle hook fires: `updatedPeriodType`, `updatedCustomStart`, `updatedCustomEnd`. Mounting from a URL query string does NOT dispatch (the page-load is the initial state).
+
+## How to subscribe — Livewire widget
+
+```blade
+<div
+    x-data
+    @klassci:group-portal:period-change.window="$wire.onPeriodChanged($event.detail)"
+>
+    {{ $this->render() }}
+</div>
+```
+
+```php
+use App\Support\Period\PeriodEventContract;
+use App\Support\Period\PeriodType;
+use Carbon\CarbonImmutable;
+
+class MyPeriodAwareWidget extends Widget
+{
+    public ?PeriodType $type = null;
+    public ?CarbonImmutable $start = null;
+    public ?CarbonImmutable $end = null;
+
+    public function onPeriodChanged(array $payload): void
+    {
+        $this->type = PeriodType::tryFromSafe($payload['type'] ?? null);
+
+        try {
+            $this->start = isset($payload['start'])
+                ? CarbonImmutable::parse($payload['start'])
+                : null;
+            $this->end = isset($payload['end'])
+                ? CarbonImmutable::parse($payload['end'])
+                : null;
+        } catch (\Throwable) {
+            // Malformed ISO → log + fall back to default.
+            logger()->warning('[group-portal] malformed period payload', $payload);
+            $this->type = PeriodType::default();
+            $this->start = null;
+            $this->end = null;
+        }
+
+        // Trigger recompute of getStats() / $this->dispatch('refresh') etc.
+    }
+}
+```
+
+## How to subscribe — vanilla JS / Alpine
+
+```js
+window.addEventListener('klassci:group-portal:period-change', (event) => {
+    const { type, start, end, label } = event.detail;
+    // Update your local state / re-fetch data.
+});
+```
+
+## Testing subscribers
+
+```php
+use App\Livewire\Group\PortalPeriodSelector;
+use App\Support\Period\PeriodEventContract;
+use Livewire\Livewire;
+
+it('widget recomputes on period change', function () {
+    Livewire::test(MyWidget::class)
+        ->dispatch(PeriodEventContract::EVENT_NAME,
+            type: 'current-month',
+            start: '2026-04-01T00:00:00+00:00',
+            end: '2026-04-30T23:59:59+00:00',
+            label: 'Avril 2026',
+        )
+        ->assertSet('type', \App\Support\Period\PeriodType::CurrentMonth);
+});
+```
+
+## Versioning
+
+This contract is **frozen at PR4c**. Any breaking change (new required payload key, renamed key, semantics change) MUST:
+
+1. Introduce a new namespaced event (e.g. `klassci:group-portal:period-change:v2`)
+2. Keep the old event firing in parallel for at least one release cycle
+3. Deprecate old event name in this file with a migration note
+4. Remove only after all known consumers have migrated
+
+Adding NEW keys to the existing payload is acceptable (consumers read with `?? null`), but should still be documented in this file.
+
+## Related
+
+- `app/Support/Period/PeriodEventContract.php` — PHP constants (import here)
+- `app/Support/Period/PeriodInterface.php` — backend value object (derive `cacheKey()` server-side)
+- `app/Livewire/Group/PortalPeriodSelector.php` — producer
+- `docs/PORTAIL_GROUPE_DEPLOIEMENT.md` — deployment runbook

--- a/docs/PORTAIL_GROUPE_DEPLOIEMENT.md
+++ b/docs/PORTAIL_GROUPE_DEPLOIEMENT.md
@@ -150,3 +150,30 @@ Le navigation item "Établissements" affiche un badge dynamique :
 - Badge `danger` (rouge) : ≥ 1 alerte `critical`
 
 Compte calculé via `TenantAggregationService::getGroupHealthMetrics()['alerts']` — cache TTL 5 min, donc l'impact perf est négligeable.
+
+---
+
+## PR4c — Event contract (pour subscribers futurs)
+
+Livré dans #12. Le sélecteur de période émet un event frozen lors de chaque changement validé (flag ON + résolution valide). **Aucun widget ne consomme en PR4c** — l'infra est prête pour la migration groupée des widgets time-windowed en PR4d.
+
+### Event
+
+    klassci:group-portal:period-change
+
+Payload : `{type, start (ISO8601), end (ISO8601), label}`. Pas de `cacheKey` (fuite impl backend).
+
+Doc complète + exemples subscribers : [GROUP_PORTAL_EVENT_CONTRACT.md](GROUP_PORTAL_EVENT_CONTRACT.md).
+
+### Quand dispatch
+
+- `period_selector_enabled=true` ET
+- Period résolue non-null (custom-range avec dates manquantes/malformées → skip)
+
+### Non-wiring
+
+Les 7 widgets (`KpiOverviewWidget`, `GroupAlertsWidget`, `GroupAgingWidget`, `EstablishmentCardsWidget`, `GroupWelcomeWidget`, `RevenueComparisonWidget`, `EnrollmentWidget`) ne réagissent pas encore à l'event en PR4c. Si un observateur externe souscrit avant PR4d, il fonctionnera immédiatement (contract stable).
+
+### Migration widgets (PR4d prévu)
+
+Groupe cohérent à migrer ensemble : `KpiOverviewWidget` + `RevenueComparisonWidget` + `GroupAgingWidget` (tous time-windowed MoM/YoY/aging). Les 4 autres widgets (Alerts, EstablishmentCards, Welcome, Enrollment) ne sont PAS période-aware par nature — ne pas migrer.

--- a/resources/views/livewire/group/portal-period-selector.blade.php
+++ b/resources/views/livewire/group/portal-period-selector.blade.php
@@ -3,6 +3,8 @@
     $panelId = 'gp-period-custom-panel-' . $this->getId();
     $currentValue = $this->currentType->value;
     $debounceMs = (int) config('group_portal.period_selector_debounce_ms', 300);
+    $eventName = \App\Support\Period\PeriodEventContract::EVENT_NAME;
+    $presetPayloads = $this->presetPayloads;
 @endphp
 
 <div
@@ -15,6 +17,28 @@
         localEnd: @js($customEnd),
         debounceId: null,
         debounceMs: {{ $debounceMs }},
+        eventName: @js($eventName),
+        presetPayloads: @js($presetPayloads),
+        buildPayload() {
+            if (this.localType === 'custom-range') {
+                if (!this.localStart || !this.localEnd) return null;
+                const start = new Date(this.localStart);
+                const end = new Date(this.localEnd);
+                if (isNaN(start) || isNaN(end) || start > end) return null;
+                return {
+                    type: 'custom-range',
+                    start: new Date(start.setHours(0, 0, 0, 0)).toISOString(),
+                    end: new Date(end.setHours(23, 59, 59, 0)).toISOString(),
+                    label: `${this.localStart} → ${this.localEnd}`,
+                };
+            }
+            return this.presetPayloads[this.localType] ?? null;
+        },
+        broadcast() {
+            const payload = this.buildPayload();
+            if (!payload) return;
+            window.dispatchEvent(new CustomEvent(this.eventName, { detail: payload }));
+        },
         select(value) {
             this.localType = value;
             this.open = false;
@@ -30,6 +54,7 @@
             clearTimeout(this.debounceId);
             this.debounceId = setTimeout(() => {
                 $wire.set('periodType', this.localType);
+                this.broadcast();
             }, this.debounceMs);
         },
         commitRange() {
@@ -37,6 +62,7 @@
             this.debounceId = setTimeout(() => {
                 $wire.set('customStart', this.localStart);
                 $wire.set('customEnd', this.localEnd);
+                this.broadcast();
             }, this.debounceMs);
         },
         toggleListbox() {

--- a/tests/Feature/Livewire/PortalPeriodSelectorDispatchTest.php
+++ b/tests/Feature/Livewire/PortalPeriodSelectorDispatchTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Livewire\Group\PortalPeriodSelector;
+use App\Support\Period\PeriodEventContract;
+use Livewire\Livewire;
+
+it('dispatches period-change event when periodType changes to current-month', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'current-month')
+        ->assertDispatched(PeriodEventContract::EVENT_NAME);
+});
+
+it('dispatches period-change event with expected payload keys (no cacheKey)', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'current-year')
+        ->assertDispatched(PeriodEventContract::EVENT_NAME, function (string $name, array $params) {
+            // Livewire 3 named args → $params is assoc: ['type' => ..., 'start' => ..., ...]
+            expect(array_keys($params))->toBe(PeriodEventContract::PAYLOAD_KEYS);
+            expect($params)->not->toHaveKey('cacheKey');
+
+            return true;
+        });
+});
+
+it('dispatched payload contains ISO8601 dates from PeriodInterface', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'current-year')
+        ->assertDispatched(PeriodEventContract::EVENT_NAME, function (string $name, array $params) {
+            expect($params['type'])->toBe('current-year');
+            expect($params['start'])->toMatch('/^\d{4}-01-01T00:00:00/');
+            expect($params['end'])->toMatch('/^\d{4}-12-31T23:59:59/');
+            expect($params['label'])->toContain((string) date('Y'));
+
+            return true;
+        });
+});
+
+it('does NOT dispatch when custom-range selected with missing dates', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'custom-range')
+        ->assertNotDispatched(PeriodEventContract::EVENT_NAME);
+});
+
+it('does NOT dispatch when custom-range dates are malformed', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'custom-range')
+        ->set('customStart', 'not-a-date')
+        ->set('customEnd', '<xss>')
+        ->assertNotDispatched(PeriodEventContract::EVENT_NAME);
+});
+
+it('dispatches when custom-range dates are both valid', function () {
+    Livewire::test(PortalPeriodSelector::class)
+        ->set('periodType', 'custom-range')
+        ->set('customStart', '2026-01-15')
+        ->set('customEnd', '2026-03-20')
+        ->assertDispatched(PeriodEventContract::EVENT_NAME, function (string $name, array $params) {
+            expect($params['type'])->toBe('custom-range');
+            expect($params['start'])->toContain('2026-01-15');
+            expect($params['end'])->toContain('2026-03-20');
+
+            return true;
+        });
+});
+
+it('injecting a malicious URL period falls back to default WITHOUT leaking payload', function () {
+    Livewire::withQueryParams(['period' => '<script>alert(1)</script>'])
+        ->test(PortalPeriodSelector::class)
+        ->assertSet('periodType', 'current-year')
+        ->assertDontSee('<script>', false);
+    // No dispatch here — mount() normalizes in place, does not trigger updated* lifecycle hooks.
+});

--- a/tests/Unit/Support/Period/PeriodEventContractTest.php
+++ b/tests/Unit/Support/Period/PeriodEventContractTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Support\Period\PeriodEventContract;
+
+it('EVENT_NAME is a frozen stable string (consumer contract)', function () {
+    expect(PeriodEventContract::EVENT_NAME)->toBe('klassci:group-portal:period-change');
+});
+
+it('EVENT_NAME uses a namespaced format to avoid collisions', function () {
+    $name = PeriodEventContract::EVENT_NAME;
+
+    expect($name)
+        ->toStartWith('klassci:')
+        ->toContain(':group-portal:')
+        ->not->toContain(' ')
+        ->not->toContain('_');
+});
+
+it('PAYLOAD_KEYS lists exactly the documented fields in order', function () {
+    expect(PeriodEventContract::PAYLOAD_KEYS)
+        ->toBe(['type', 'start', 'end', 'label']);
+});
+
+it('PAYLOAD_KEYS does NOT expose cacheKey (backend internal)', function () {
+    expect(PeriodEventContract::PAYLOAD_KEYS)->not->toContain('cacheKey');
+});
+
+it('is final and cannot be subclassed (frozen contract)', function () {
+    $reflection = new ReflectionClass(PeriodEventContract::class);
+
+    expect($reflection->isFinal())->toBeTrue();
+});
+
+it('constants are public (consumable by widgets and tests)', function () {
+    $reflection = new ReflectionClass(PeriodEventContract::class);
+
+    foreach (['EVENT_NAME', 'PAYLOAD_KEYS'] as $constant) {
+        $ref = $reflection->getReflectionConstant($constant);
+        expect($ref)->not->toBeFalse();
+        expect($ref->isPublic())->toBeTrue();
+    }
+});


### PR DESCRIPTION
Closes #12

## Résumé

Infrastructure event pour portail groupe. **Scope SLIM** post-audit 4 axes : le plan initial (migrer KpiOverviewWidget seul) était un wrong cut sémantique — le widget consomme 3 méthodes time-windowed différentes (KPI + Trends MoM/YoY + Aging 30/60/90j). Migrer une seule produit un widget incohérent. PR4c livre donc UNIQUEMENT l'infra event, migration reportée PR4d groupée par cohérence.

## Commit unique (\`65b8163\`)

### Event contract frozen
- \`App\Support\Period\PeriodEventContract\` (final class) avec constantes publiques
- \`EVENT_NAME = 'klassci:group-portal:period-change'\` (namespacé anti-collision)
- \`PAYLOAD_KEYS = ['type', 'start', 'end', 'label']\` — **PAS de cacheKey** (fuite impl backend)
- Docblock complet + exemples subscribers

### Dispatch 2 layers (ceinture-bretelles)
- **PHP** : \`$this->dispatch()\` dans \`updatedPeriodType\` / \`updatedCustomStart\` / \`updatedCustomEnd\` (pour tests Pest + consumers Livewire-internal via \`#[On]\`)
- **Alpine** : \`window.dispatchEvent(new CustomEvent())\` après commit (Livewire 3.x ne bubble pas toujours en browser CustomEvent natif quand le nom contient des colons)

### Payload computation (zéro roundtrip supplémentaire)
- PHP pré-compute \`presetPayloads\` pour CurrentMonth/CurrentYear au render → JSON dans \`x-data\`
- Alpine \`buildPayload()\` pick preset OR construit CustomRange client-side depuis \`localStart/localEnd\`

### Tests — 79 pass / 203 assertions (+13 PR4c)
- \`PeriodEventContractTest\` (6) : EVENT_NAME stable, format namespacé, PAYLOAD_KEYS ordered, NO cacheKey, final class
- \`PortalPeriodSelectorDispatchTest\` (7) : dispatch on update, payload shape, ISO8601 dates, skip custom-range incomplet, URL XSS reject

### Visual check dev-browser
Flag ON → click "Mois en cours" → event fires sur \`window\` avec payload exact :
\`\`\`json
{
  \"type\": \"current-month\",
  \"start\": \"2026-04-01T00:00:00+00:00\",
  \"end\": \"2026-04-30T23:59:59+00:00\",
  \"label\": \"avril 2026\"
}
\`\`\`
Pas de \`cacheKey\` exposé ✓.

### Docs nouveaux
- \`docs/GROUP_PORTAL_EVENT_CONTRACT.md\` — spec frozen + subscriber examples (Livewire widget, vanilla JS, tests) + versioning policy
- \`docs/PORTAIL_GROUPE_DEPLOIEMENT.md\` — section PR4c

## Not in scope — reporté PR4d

- **Migration widgets** KpiOverview + RevenueComparison + GroupAging (GROUPÉS par cohérence time-windowed, pas un seul)
- Provider signature change \`computeGroupKpis(Group, ?Period = null)\`
- Cache key period-aware \`group_v2_{id}_kpis_{period->cacheKey()}\` + \`Cache::lock()\` thundering-herd
- Feature flag \`widgets_period_aware_enabled\`
- Tests E2E Dusk/Playwright (Pest + dev-browser suffit)
- Split Health/Trends providers (conditionnel si dette observée)

## 4-axis audit post-implementation

| Axe | Verdict | Justification |
|---|---|---|
| Architecture | PASS | Event infra isolée, constantes frozen, zéro widget touché |
| Qualité vs Vitesse | PASS | 13 nouveaux tests + visual check window event |
| Production-grade | PASS | Flag gated, graceful skip si Period null, 2-layer dispatch defensive, zéro risque widgets |
| SOLID | PASS | Const class (fin magic strings), LSP intact, OCP payload extensible, DIP via constantes |

## Checklist deploy

- [ ] Merge → \`composer install && php artisan config:clear\`
- [ ] Flag selector reste OFF par défaut (\`GROUP_PORTAL_PERIOD_SELECTOR\`)
- [ ] Quand activé, l'event fire sur window mais AUCUN widget consomme en PR4c
- [ ] Subscribers futurs peuvent déjà s'abonner → contrat stable