### PR TITLE
chore(group-portal): simplify PR4 post-review

### DIFF
--- a/app/Filament/Group/Resources/EstablishmentResource.php
+++ b/app/Filament/Group/Resources/EstablishmentResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Group\Resources;
 
+use App\Enums\AlertSeverity;
 use App\Filament\Group\Resources\EstablishmentResource\Pages;
 use App\Models\Tenant;
 use App\Services\TenantAggregationService;
@@ -26,48 +27,51 @@ class EstablishmentResource extends Resource
 
     protected static ?int $navigationSort = 2;
 
-    public static function getNavigationBadge(): ?string
-    {
-        $user = auth('group')->user();
-        $group = $user?->group;
+    /** @var array<int, list<array<string,mixed>>>  memoized per-request alerts keyed by group id */
+    private static array $alertsCache = [];
 
+    /** @return list<array<string,mixed>> */
+    private static function currentGroupAlerts(): array
+    {
+        $group = auth('group')->user()?->group;
         if (! $group) {
-            return null;
+            return [];
+        }
+
+        if (isset(self::$alertsCache[$group->id])) {
+            return self::$alertsCache[$group->id];
         }
 
         try {
-            $alerts = app(TenantAggregationService::class)->getGroupHealthMetrics($group)['alerts'] ?? [];
-            $count = count($alerts);
-
-            return $count > 0 ? (string) $count : null;
+            return self::$alertsCache[$group->id] =
+                app(TenantAggregationService::class)->getGroupHealthMetrics($group)['alerts'] ?? [];
         } catch (\Throwable) {
             // Silent degradation — badge is non-critical.
-            return null;
+            return self::$alertsCache[$group->id] = [];
         }
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = count(self::currentGroupAlerts());
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function getNavigationBadgeColor(): ?string
     {
-        $user = auth('group')->user();
-        $group = $user?->group;
-
-        if (! $group) {
+        $alerts = self::currentGroupAlerts();
+        if (empty($alerts)) {
             return null;
         }
 
-        try {
-            $alerts = app(TenantAggregationService::class)->getGroupHealthMetrics($group)['alerts'] ?? [];
-
-            foreach ($alerts as $alert) {
-                if (($alert['severity'] ?? null) === 'critical') {
-                    return 'danger';
-                }
+        foreach ($alerts as $alert) {
+            if (($alert['severity'] ?? null) === AlertSeverity::Critical->value) {
+                return 'danger';
             }
-
-            return count($alerts) > 0 ? 'warning' : null;
-        } catch (\Throwable) {
-            return null;
         }
+
+        return 'warning';
     }
 
     public static function getEloquentQuery(): Builder

--- a/app/Livewire/Group/PortalPeriodSelector.php
+++ b/app/Livewire/Group/PortalPeriodSelector.php
@@ -60,26 +60,32 @@ class PortalPeriodSelector extends Component
     /**
      * Dispatches the frozen period-change event (see PeriodEventContract).
      * Silently skipped when the current selection doesn't resolve to a Period
-     * (e.g. custom-range with missing/malformed dates) — the UI remains open
-     * without committing an ambiguous range to consumers.
+     * (e.g. custom-range with missing/malformed dates).
      */
     private function dispatchPeriodChange(): void
     {
-        $period = $this->resolvedPeriod;
+        $payload = $this->resolvedPayload;
 
-        if ($period === null) {
+        if ($payload === null) {
             return;
         }
 
-        // Livewire 3 sends named args as event.detail keys — consumers read
-        // $event.detail.type, .start, .end, .label on the browser side.
-        $this->dispatch(
-            PeriodEventContract::EVENT_NAME,
-            type: $this->currentType->value,
-            start: $period->startDate()->toIso8601String(),
-            end: $period->endDate()->toIso8601String(),
-            label: $period->label(),
-        );
+        // Livewire 3 sends named args as event.detail keys.
+        $this->dispatch(PeriodEventContract::EVENT_NAME, ...$payload);
+    }
+
+    /**
+     * Canonical payload for the current selection — single builder used by
+     * both the PHP dispatch and the Alpine broadcast (via blade @js injection).
+     */
+    private function buildPayload(PeriodInterface $period, PeriodType $type): array
+    {
+        return [
+            'type' => $type->value,
+            'start' => $period->startDate()->toIso8601String(),
+            'end' => $period->endDate()->toIso8601String(),
+            'label' => $period->label(),
+        ];
     }
 
     public function getCurrentTypeProperty(): PeriodType
@@ -123,16 +129,7 @@ class PortalPeriodSelector extends Component
     {
         $period = $this->resolvedPeriod;
 
-        if ($period === null) {
-            return null;
-        }
-
-        return [
-            'type' => $this->currentType->value,
-            'start' => $period->startDate()->toIso8601String(),
-            'end' => $period->endDate()->toIso8601String(),
-            'label' => $period->label(),
-        ];
+        return $period === null ? null : $this->buildPayload($period, $this->currentType);
     }
 
     /**
@@ -148,13 +145,10 @@ class PortalPeriodSelector extends Component
         $presets = [];
 
         foreach ([PeriodType::CurrentMonth, PeriodType::CurrentYear] as $type) {
-            $period = PeriodFactory::make($type->value);
-            $presets[$type->value] = [
-                'type' => $type->value,
-                'start' => $period->startDate()->toIso8601String(),
-                'end' => $period->endDate()->toIso8601String(),
-                'label' => $period->label(),
-            ];
+            $presets[$type->value] = $this->buildPayload(
+                PeriodFactory::make($type->value),
+                $type,
+            );
         }
 
         return $presets;


### PR DESCRIPTION
Applied highest-ROI findings from /simplify 3-agent review on PR4a+b+c+d merged code.

## Fixes appliqués

### 1. EstablishmentResource navigation badge
- Use `AlertSeverity::Critical->value` instead of hardcoded `'critical'` (reuse enum, stays in sync)
- Memoize `currentGroupAlerts()` per-request via static array — avoids 2× redis roundtrip for `getNavigationBadge` + `getNavigationBadgeColor` on every sidebar render
- Single try/catch at source instead of duplicated across 2 methods

### 2. PortalPeriodSelector DRY payload builder
- Extract `buildPayload(PeriodInterface, PeriodType)` — single source of truth for `{type, start, end, label}` shape
- `resolvedPayload` + `presetPayloads` + `dispatchPeriodChange` now tous délèguent au builder (3 → 1 place)
- `dispatch()` utilise spread `...$payload` au lieu de redéclarer les 4 named args

## Tests

90 passants / 312 assertions inchangés.

## Skipped findings

- Collapse 6 `Cache::remember` getters → `CacheKind` enum : bigger refactor hot path, reporté
- Drop `$label` param `TenantAggregator` : 6 call sites, low value
- 3 Period classes → 1 + match : defensible SRP per critic, YAGNI
- Typed DTOs provider outputs : higher churn, reporté
- EstablishmentResource table N+1 : pre-existing pattern, not PR4 regression
- `@js()` in x-data blade : fonctionne fiable, la règle data-* est pour cas où `@json` casse le HTML parser

## Context

Agents lancés : reuse-review / quality-review / efficiency-review (3 parallèles). Findings aggregés, filtered par ROI vs risk.