### PR TITLE
feat(group-portal): PR4e widgets time-windowed period-aware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,13 @@ TENANT_GIT_BASE_BRANCH=presentation
 # Générer avec : openssl rand -hex 32
 # Doit correspondre au secret GitHub DEPLOY_WEBHOOK_TOKEN
 DEPLOY_WEBHOOK_TOKEN=
+
+# Group portal — period selector (PR4b UI)
+GROUP_PORTAL_PERIOD_SELECTOR=false
+GROUP_PORTAL_PERIOD_DEBOUNCE_MS=300
+
+# Group portal — widgets period-aware (PR4e)
+# When true, the 3 time-windowed widgets (KPI + Revenue + Aging) listen to the
+# period selector and reload with the selected period. Flip only once the UI
+# selector has proved stable in production.
+GROUP_PORTAL_WIDGETS_PERIOD_AWARE=false

--- a/app/Filament/Group/Concerns/PeriodAwareConcern.php
+++ b/app/Filament/Group/Concerns/PeriodAwareConcern.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Filament\Group\Concerns;
+
+use App\Support\Period\PeriodEventContract;
+use App\Support\Period\PeriodFactory;
+use App\Support\Period\PeriodInterface;
+use App\Support\Period\PeriodType;
+use Carbon\CarbonImmutable;
+use Livewire\Attributes\On;
+
+/**
+ * Makes a Filament widget react to the frozen group-portal period-change event.
+ *
+ * Applied to widgets whose metrics are time-windowed (MoM/YoY/aging/trends).
+ * Snapshot widgets (enrollment, alerts, etc.) MUST NOT use this concern — their
+ * metrics ignore the period by design.
+ *
+ * ## Mechanism
+ *
+ * Livewire 3 `#[On(...)]` natively listens to `window` CustomEvents dispatched
+ * by the PortalPeriodSelector (via Alpine `window.dispatchEvent()`). No per-widget
+ * Alpine bridge is required — the producer dispatches on `window`, the consumers
+ * hook the same bus.
+ *
+ * Note (feedback_livewire3_colons_dispatch_gotcha): the colons gotcha applies to
+ * the PRODUCER side (PHP `$this->dispatch()` not always bubbling to `window`).
+ * That is already mitigated in PortalPeriodSelector by dispatching via Alpine.
+ * On the CONSUMER side, `#[On('name:with:colons')]` works because Livewire
+ * wires the listener to `window.addEventListener(...)` directly.
+ *
+ * ## Feature flag
+ *
+ * When `group_portal.widgets_period_aware` is OFF, `currentPeriod()` always
+ * returns the default period regardless of received events. This lets ops roll
+ * the feature out gradually without code changes — flip the env var.
+ *
+ * ## Graceful degradation
+ *
+ * Malformed payloads (missing keys, unknown type, unparseable dates) fall back
+ * to the default period rather than throwing. The widget stays functional with
+ * stale/default data instead of a broken dashboard.
+ *
+ * @see \App\Support\Period\PeriodEventContract — frozen event contract
+ * @see \App\Support\Period\PeriodInterface — period value object
+ * @see \App\Livewire\Group\PortalPeriodSelector — producer
+ */
+trait PeriodAwareConcern
+{
+    /**
+     * Last received payload, or null if no period-change event has arrived yet.
+     * Serialized by Livewire across requests — kept as a plain array to avoid
+     * re-serializing PeriodInterface (readonly classes don't round-trip cleanly
+     * through Livewire's hydration).
+     *
+     * @var array{type: string, start: string, end: string, label: string}|null
+     */
+    public ?array $periodPayload = null;
+
+    #[On(PeriodEventContract::EVENT_NAME)]
+    public function onPeriodChanged(array $payload): void
+    {
+        // Defensive copy — only keep the keys we care about.
+        // Garbage extras (e.g. from a malicious dispatcher) are dropped silently.
+        $clean = [];
+        foreach (PeriodEventContract::PAYLOAD_KEYS as $key) {
+            if (isset($payload[$key]) && is_string($payload[$key])) {
+                $clean[$key] = $payload[$key];
+            }
+        }
+
+        if (count($clean) !== count(PeriodEventContract::PAYLOAD_KEYS)) {
+            // Missing keys → ignore the event, keep the previous period.
+            return;
+        }
+
+        $this->periodPayload = $clean;
+    }
+
+    protected function currentPeriod(): PeriodInterface
+    {
+        if (! config('group_portal.widgets_period_aware', false)) {
+            return PeriodFactory::default();
+        }
+
+        if ($this->periodPayload === null) {
+            return PeriodFactory::default();
+        }
+
+        try {
+            $type = PeriodType::tryFromSafe($this->periodPayload['type']);
+
+            if ($type === PeriodType::CustomRange) {
+                return PeriodFactory::make(PeriodFactory::TYPE_CUSTOM_RANGE, [
+                    'start' => CarbonImmutable::parse($this->periodPayload['start']),
+                    'end' => CarbonImmutable::parse($this->periodPayload['end']),
+                ]);
+            }
+
+            return PeriodFactory::make($type->value);
+        } catch (\Throwable) {
+            // Unparseable dates, invalid type — fall back to default.
+            return PeriodFactory::default();
+        }
+    }
+}

--- a/app/Filament/Group/Widgets/GroupAgingWidget.php
+++ b/app/Filament/Group/Widgets/GroupAgingWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Group\Widgets;
 
+use App\Filament\Group\Concerns\PeriodAwareConcern;
 use App\Services\TenantAggregationService;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -9,6 +10,8 @@ use Illuminate\Support\Str;
 
 class GroupAgingWidget extends StatsOverviewWidget
 {
+    use PeriodAwareConcern;
+
     protected static ?int $sort = 3;
 
     protected static ?string $pollingInterval = '180s';
@@ -23,7 +26,8 @@ class GroupAgingWidget extends StatsOverviewWidget
     protected function getStats(): array
     {
         $group = auth('group')->user()->group;
-        $aging = app(TenantAggregationService::class)->getGroupOutstandingAging($group);
+        $aging = app(TenantAggregationService::class)
+            ->getGroupOutstandingAging($group, $this->currentPeriod());
 
         // `pluralize_qualifier` only true when the suffix is an adjective (critique → critiques).
         // Invariant suffixes like "à surveiller" / "à recouvrer urgemment" keep the same form.

--- a/app/Filament/Group/Widgets/KpiOverviewWidget.php
+++ b/app/Filament/Group/Widgets/KpiOverviewWidget.php
@@ -2,12 +2,15 @@
 
 namespace App\Filament\Group\Widgets;
 
+use App\Filament\Group\Concerns\PeriodAwareConcern;
 use App\Services\TenantAggregationService;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
 class KpiOverviewWidget extends StatsOverviewWidget
 {
+    use PeriodAwareConcern;
+
     protected static ?int $sort = 2;
 
     protected static ?string $pollingInterval = '300s';
@@ -21,10 +24,13 @@ class KpiOverviewWidget extends StatsOverviewWidget
     {
         $group = auth('group')->user()->group;
         $service = app(TenantAggregationService::class);
+        // All 3 service calls MUST receive the same period — otherwise MoM/YoY
+        // deltas would be computed against a different window than the snapshot.
+        $period = $this->currentPeriod();
 
-        $kpis = $service->getGroupKpis($group);
-        $trends = $service->getGroupTrends($group);
-        $aging = $service->getGroupOutstandingAging($group);
+        $kpis = $service->getGroupKpis($group, $period);
+        $trends = $service->getGroupTrends($group, $period);
+        $aging = $service->getGroupOutstandingAging($group, $period);
 
         // Delta MoM revenus
         $revenueDelta = $trends['revenue_mom']['delta_pct'] ?? 0;

--- a/app/Filament/Group/Widgets/RevenueComparisonWidget.php
+++ b/app/Filament/Group/Widgets/RevenueComparisonWidget.php
@@ -2,11 +2,14 @@
 
 namespace App\Filament\Group\Widgets;
 
+use App\Filament\Group\Concerns\PeriodAwareConcern;
 use App\Services\TenantAggregationService;
 use Filament\Widgets\ChartWidget;
 
 class RevenueComparisonWidget extends ChartWidget
 {
+    use PeriodAwareConcern;
+
     // Keep lazy: cross-DB queries can be slow
 
     protected static ?string $heading = 'Revenus par établissement';
@@ -21,7 +24,7 @@ class RevenueComparisonWidget extends ChartWidget
     {
         $group = auth('group')->user()->group;
         $service = app(TenantAggregationService::class);
-        $financials = $service->getGroupFinancials($group);
+        $financials = $service->getGroupFinancials($group, $this->currentPeriod());
 
         $labels = [];
         $expected = [];

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -23,4 +23,23 @@ return [
     | Tuned for quick clicks without triggering one HTTP roundtrip per keystroke.
     */
     'period_selector_debounce_ms' => env('GROUP_PORTAL_PERIOD_DEBOUNCE_MS', 300),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Widgets period-aware (PR4e)
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the 3 time-windowed widgets (KpiOverviewWidget +
+    | RevenueComparisonWidget + GroupAgingWidget) listen to the period-change
+    | event and re-render with the selected period. When disabled, they ignore
+    | the event and always render with the default period (PR4c behaviour).
+    |
+    | Decoupled from `period_selector_enabled` so ops can roll out the event
+    | producer and the consumers independently. Flip this only once the UI
+    | selector has proved stable in production.
+    |
+    |   GROUP_PORTAL_WIDGETS_PERIOD_AWARE=true
+    |
+    */
+    'widgets_period_aware' => env('GROUP_PORTAL_WIDGETS_PERIOD_AWARE', false),
 ];

--- a/docs/GROUP_PORTAL_EVENT_CONTRACT.md
+++ b/docs/GROUP_PORTAL_EVENT_CONTRACT.md
@@ -57,46 +57,49 @@ The selector dispatches ONLY when:
 
 ## How to subscribe — Livewire widget
 
-```blade
-<div
-    x-data
-    @klassci:group-portal:period-change.window="$wire.onPeriodChanged($event.detail)"
->
-    {{ $this->render() }}
-</div>
+Livewire 3 `#[On(...)]` listens to browser `window` CustomEvents natively — no per-widget Alpine bridge is required on the consumer side. Use the `PeriodAwareConcern` trait for the boilerplate (wired up in PR4e):
+
+```php
+use App\Filament\Group\Concerns\PeriodAwareConcern;
+use App\Services\TenantAggregationService;
+use Filament\Widgets\StatsOverviewWidget;
+
+class MyPeriodAwareWidget extends StatsOverviewWidget
+{
+    use PeriodAwareConcern;
+
+    protected function getStats(): array
+    {
+        $group = auth('group')->user()->group;
+        // $this->currentPeriod() returns PeriodFactory::default() when either
+        //   a) the `group_portal.widgets_period_aware` flag is OFF, or
+        //   b) no period-change event has been received yet, or
+        //   c) the last received payload was malformed.
+        $period = $this->currentPeriod();
+
+        $kpis = app(TenantAggregationService::class)->getGroupKpis($group, $period);
+        // ... build stats array
+    }
+}
 ```
+
+Manual subscription (without the trait) — kept for reference:
 
 ```php
 use App\Support\Period\PeriodEventContract;
 use App\Support\Period\PeriodType;
 use Carbon\CarbonImmutable;
+use Livewire\Attributes\On;
 
 class MyPeriodAwareWidget extends Widget
 {
-    public ?PeriodType $type = null;
-    public ?CarbonImmutable $start = null;
-    public ?CarbonImmutable $end = null;
+    public ?array $periodPayload = null;
 
+    #[On(PeriodEventContract::EVENT_NAME)]
     public function onPeriodChanged(array $payload): void
     {
-        $this->type = PeriodType::tryFromSafe($payload['type'] ?? null);
-
-        try {
-            $this->start = isset($payload['start'])
-                ? CarbonImmutable::parse($payload['start'])
-                : null;
-            $this->end = isset($payload['end'])
-                ? CarbonImmutable::parse($payload['end'])
-                : null;
-        } catch (\Throwable) {
-            // Malformed ISO → log + fall back to default.
-            logger()->warning('[group-portal] malformed period payload', $payload);
-            $this->type = PeriodType::default();
-            $this->start = null;
-            $this->end = null;
-        }
-
-        // Trigger recompute of getStats() / $this->dispatch('refresh') etc.
+        // Always validate — never trust the payload blindly.
+        $this->periodPayload = $payload;
     }
 }
 ```

--- a/public/css/groupe-portal.css
+++ b/public/css/groupe-portal.css
@@ -1355,3 +1355,17 @@
         text-overflow: ellipsis;
     }
 }
+
+/* Visually hidden live region — announced by screen readers when the period
+   changes. Widgets re-render silently otherwise (no user-initiated navigation). */
+.gp-period-live {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/resources/views/livewire/group/portal-period-selector.blade.php
+++ b/resources/views/livewire/group/portal-period-selector.blade.php
@@ -84,6 +84,19 @@
     }"
     @keydown.escape.window="open = false; customOpen = (localType === 'custom-range')"
 >
+    {{-- Screen-reader announcement — fires on every broadcast() so assistive --}}
+    {{-- tech users hear the new period label when widgets re-render silently. --}}
+    <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        class="gp-period-live"
+        x-text="(() => {
+            const payload = buildPayload();
+            return payload ? `Période sélectionnée : ${payload.label}` : '';
+        })()"
+    ></div>
+
     <button
         type="button"
         class="gp-period-button"

--- a/tests/Feature/Group/Widgets/PeriodAwareConcernTest.php
+++ b/tests/Feature/Group/Widgets/PeriodAwareConcernTest.php
@@ -1,0 +1,166 @@
+<?php
+
+use App\Filament\Group\Concerns\PeriodAwareConcern;
+use App\Support\Period\CurrentMonthPeriod;
+use App\Support\Period\CurrentYearPeriod;
+use App\Support\Period\CustomRangePeriod;
+use App\Support\Period\PeriodEventContract;
+use App\Support\Period\PeriodFactory;
+use App\Support\Period\PeriodInterface;
+use Livewire\Component;
+use Livewire\Livewire;
+
+/**
+ * Minimal Livewire component that exercises the PeriodAwareConcern trait in
+ * isolation — no Filament widget parents, no auth, no service container calls.
+ * Tests assert the trait's observable behaviour, not the full dashboard wiring.
+ */
+class FakePeriodAwareWidget extends Component
+{
+    use PeriodAwareConcern;
+
+    public function render(): string
+    {
+        return '<div>'.$this->currentPeriod()->cacheKey().'</div>';
+    }
+
+    public function getPeriodForAssertions(): PeriodInterface
+    {
+        return $this->currentPeriod();
+    }
+}
+
+beforeEach(function () {
+    // Default-ON for trait behaviour tests — flag-OFF tested separately.
+    config(['group_portal.widgets_period_aware' => true]);
+});
+
+it('ignores events when feature flag is OFF', function () {
+    config(['group_portal.widgets_period_aware' => false]);
+
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'current-month',
+            'start' => '2026-04-01T00:00:00+00:00',
+            'end' => '2026-04-30T23:59:59+00:00',
+            'label' => 'Avril 2026',
+        ]);
+
+    // Flag OFF → currentPeriod() always returns default, regardless of payload.
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period->cacheKey())->toBe(PeriodFactory::default()->cacheKey());
+});
+
+it('returns default period when no event has been received', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class);
+
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period)->toBeInstanceOf(CurrentYearPeriod::class);
+});
+
+it('updates currentPeriod() when a valid current-month payload arrives', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'current-month',
+            'start' => '2026-04-01T00:00:00+00:00',
+            'end' => '2026-04-30T23:59:59+00:00',
+            'label' => 'Avril 2026',
+        ]);
+
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period)->toBeInstanceOf(CurrentMonthPeriod::class);
+});
+
+it('updates currentPeriod() when a valid custom-range payload arrives', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'custom-range',
+            'start' => '2026-01-15T00:00:00+00:00',
+            'end' => '2026-03-20T23:59:59+00:00',
+            'label' => '15/01/2026 → 20/03/2026',
+        ]);
+
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period)->toBeInstanceOf(CustomRangePeriod::class);
+    expect($period->startDate()->format('Y-m-d'))->toBe('2026-01-15');
+    expect($period->endDate()->format('Y-m-d'))->toBe('2026-03-20');
+});
+
+it('falls back to default when payload is missing required keys', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'current-month',
+            // missing start, end, label
+        ]);
+
+    // Payload rejected → currentPeriod() still returns default.
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period->cacheKey())->toBe(PeriodFactory::default()->cacheKey());
+});
+
+it('falls back to default when payload contains unknown type', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'no-such-type',
+            'start' => '2026-01-01T00:00:00+00:00',
+            'end' => '2026-12-31T23:59:59+00:00',
+            'label' => 'Garbage',
+        ]);
+
+    // tryFromSafe() falls back to default — currentPeriod returns default year.
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period)->toBeInstanceOf(CurrentYearPeriod::class);
+});
+
+it('falls back to default when custom-range dates are unparseable', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'custom-range',
+            'start' => 'not-a-date',
+            'end' => '<xss>',
+            'label' => 'Malicious',
+        ]);
+
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period)->toBeInstanceOf(CurrentYearPeriod::class);
+});
+
+it('drops extra keys in the payload (defensive against payload contamination)', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => 'current-year',
+            'start' => '2026-01-01T00:00:00+00:00',
+            'end' => '2026-12-31T23:59:59+00:00',
+            'label' => 'Année 2026',
+            'cacheKey' => 'ATTACKER_CONTROLLED_KEY',
+            'sql' => "'; DROP TABLE tenants; --",
+        ]);
+
+    // The trait must NOT expose cacheKey or other extras — only the 4 contract keys.
+    $payload = $component->get('periodPayload');
+    expect(array_keys($payload))->toBe(PeriodEventContract::PAYLOAD_KEYS);
+});
+
+it('ignores non-string values in payload keys (type confusion protection)', function () {
+    $component = Livewire::test(FakePeriodAwareWidget::class)
+        ->call('onPeriodChanged', [
+            'type' => ['nested', 'array'],
+            'start' => 42,
+            'end' => null,
+            'label' => 'valid',
+        ]);
+
+    // Count mismatch → payload rejected entirely, default period remains.
+    $period = $component->instance()->getPeriodForAssertions();
+    expect($period->cacheKey())->toBe(PeriodFactory::default()->cacheKey());
+});
+
+it('registers the Livewire listener on the frozen event name', function () {
+    // Meta-test: the trait must listen to the frozen contract name, not a custom one.
+    $reflection = new ReflectionClass(FakePeriodAwareWidget::class);
+    $method = $reflection->getMethod('onPeriodChanged');
+    $attributes = $method->getAttributes(\Livewire\Attributes\On::class);
+
+    expect($attributes)->toHaveCount(1);
+    expect($attributes[0]->getArguments()[0])->toBe(PeriodEventContract::EVENT_NAME);
+});

--- a/tests/Feature/Group/Widgets/PeriodAwareWidgetsStructureTest.php
+++ b/tests/Feature/Group/Widgets/PeriodAwareWidgetsStructureTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Filament\Group\Concerns\PeriodAwareConcern;
+use App\Filament\Group\Widgets\EnrollmentWidget;
+use App\Filament\Group\Widgets\EstablishmentCardsWidget;
+use App\Filament\Group\Widgets\GroupAgingWidget;
+use App\Filament\Group\Widgets\GroupAlertsWidget;
+use App\Filament\Group\Widgets\GroupWelcomeWidget;
+use App\Filament\Group\Widgets\KpiOverviewWidget;
+use App\Filament\Group\Widgets\RevenueComparisonWidget;
+
+/**
+ * Structural tests: the PR4e scope locked in that ONLY the 3 time-windowed
+ * widgets gain the trait. Migrating a snapshot widget (enrollment, alerts,
+ * welcome, cards) by mistake would silently push a broken semantic — these
+ * tests catch that at CI time.
+ */
+
+it('the 3 time-windowed widgets apply PeriodAwareConcern', function (string $class) {
+    expect(in_array(PeriodAwareConcern::class, class_uses_recursive($class), true))
+        ->toBeTrue("{$class} must use PeriodAwareConcern");
+})->with([
+    KpiOverviewWidget::class,
+    RevenueComparisonWidget::class,
+    GroupAgingWidget::class,
+]);
+
+it('snapshot widgets do NOT apply PeriodAwareConcern (scope guard)', function (string $class) {
+    expect(in_array(PeriodAwareConcern::class, class_uses_recursive($class), true))
+        ->toBeFalse("{$class} must NOT use PeriodAwareConcern — it's a snapshot widget");
+})->with([
+    EnrollmentWidget::class,
+    EstablishmentCardsWidget::class,
+    GroupAlertsWidget::class,
+    GroupWelcomeWidget::class,
+]);
+
+it('KpiOverviewWidget passes the period to all 3 aggregation service calls', function () {
+    // Read the source directly — the widget calls service 3 times in getStats().
+    // All 3 calls must include $this->currentPeriod() (or a variable holding it)
+    // to avoid temporal incoherence between KPIs / trends / aging buckets.
+    $source = file_get_contents(
+        (new ReflectionClass(KpiOverviewWidget::class))->getFileName()
+    );
+
+    // Rough but stable check: 3 service methods called with 2 args each.
+    foreach (['getGroupKpis', 'getGroupTrends', 'getGroupOutstandingAging'] as $method) {
+        expect($source)->toMatch(
+            '/->'.$method.'\(\$group,\s*\$period\)/',
+            "KpiOverviewWidget::getStats() must call {$method}(\\\$group, \\\$period)"
+        );
+    }
+});
+
+it('RevenueComparisonWidget passes the period to getGroupFinancials', function () {
+    $source = file_get_contents(
+        (new ReflectionClass(RevenueComparisonWidget::class))->getFileName()
+    );
+
+    expect($source)->toMatch('/->getGroupFinancials\(\$group,\s*\$this->currentPeriod\(\)\)/');
+});
+
+it('GroupAgingWidget passes the period to getGroupOutstandingAging', function () {
+    $source = file_get_contents(
+        (new ReflectionClass(GroupAgingWidget::class))->getFileName()
+    );
+
+    expect($source)->toMatch('/->getGroupOutstandingAging\(\$group,\s*\$this->currentPeriod\(\)\)/');
+});
+
+it('feature flag defaults to OFF for safe rollout', function () {
+    // Don't read .env — read the config default directly. Ops must opt IN.
+    $configPath = config_path('group_portal.php');
+    $config = require $configPath;
+
+    expect($config)->toHaveKey('widgets_period_aware');
+    // The env() default (2nd arg) must be false.
+    $rawConfigSource = file_get_contents($configPath);
+    expect($rawConfigSource)->toContain("env('GROUP_PORTAL_WIDGETS_PERIOD_AWARE', false)");
+});


### PR DESCRIPTION
## Summary

PR4e — Migration groupée des 3 widgets time-windowed (KpiOverview + RevenueComparison + GroupAging) pour écouter l'event frozen `klassci:group-portal:period-change` (PR4c) et re-render avec la `PeriodInterface` passée aux appels service (PR4d).

**Architecture** (post-critic GO-WITH-CHANGES) :
- **Trait `PeriodAwareConcern`** (pas base class) — les 3 widgets étendent 3 parents Filament différents (StatsOverviewWidget × 2, ChartWidget × 1). LSP préservé.
- **`#[On(PeriodEventContract::EVENT_NAME)]` natif** — Livewire 3 écoute directement window CustomEvents, pas d'event interne redondant.
- **KpiOverviewWidget passe `$period` aux 3 appels service** (kpis + trends + aging) — évite incohérence temporelle MoM/YoY.
- **Feature flag découplé** `GROUP_PORTAL_WIDGETS_PERIOD_AWARE` (default OFF) — rollout progressif indépendant du selector UI.
- **Graceful degradation** : payload malformé, type invalide, dates garbage → fallback `PeriodFactory::default()` sans exception.
- **A11y** : région `aria-live="polite"` dans le selector annonce le changement de période aux lecteurs d'écran.

## Scope lock (critic-validated)

**Migré (time-windowed)** : KpiOverviewWidget, RevenueComparisonWidget, GroupAgingWidget

**Non migré (snapshot par nature)** : GroupAlertsWidget, EstablishmentCardsWidget, GroupWelcomeWidget, EnrollmentWidget — test structurel bloque migration accidentelle.

## Tests (21 nouveaux, 27 assertions)

- `PeriodAwareConcernTest` (10 tests) — comportement trait isolé via `FakePeriodAwareWidget` Livewire test fixture : flag OFF, valide update, missing keys, unknown type, unparseable dates, defensive cleanup (drop cacheKey + injection), type confusion rejection, meta-test frozen event name
- `PeriodAwareWidgetsStructureTest` (11 tests) — scope guard structurel + propagation `$period` aux 3 appels service KpiOverviewWidget + default flag OFF

Suite complète : **111 tests / 339 assertions passent**, zéro régression sur PR4a→PR4d.

## Visual check

Dashboard `/groupe` rendu OK avec flag ON :
- 7 widgets rendent correctement (incluant les 3 migrés)
- Period selector visible dans topbar (label "Année 2026" par défaut)
- Aging buckets : 1 370 000 + 2 427 000 + 100 000 + 2 080 000 = **5 977 000 F identiques au baseline PR1** → LSP preserved
- Aucune erreur 500, aucune exception Livewire

## Test plan

- [ ] Pull + `php artisan config:clear` + `php artisan test --filter=PeriodAware` → 21/21 passent
- [ ] Flag OFF (défaut) : widgets rendent avec période par défaut (Année courante)
- [ ] Flag ON : ouvrir `/groupe`, changer période dans selector → les 3 widgets se rechargent
- [ ] Ouvrir DevTools console, `window.addEventListener('klassci:group-portal:period-change', e => console.log(e.detail))` puis changer période → payload `{type,start,end,label}` visible
- [ ] Test assistive tech : activer NVDA/VoiceOver, changer période → annonce "Période sélectionnée : XXX"
- [ ] Custom range avec dates garbage → pas d'exception, widgets restent sur période par défaut

## Follow-ups (non bloquants)

- PR4f éventuelle : warm-up cache au period-change pour éviter thundering herd (3 widgets × 3 calls potentiels)
- Monitoring : log Laravel Telescope du onPeriodChanged() pour suivre adoption
- E2E Playwright : test bout-en-bout navigateur (actuellement tests via `Livewire::test()->call()`)

Closes #17