### PR TITLE
feat(group-portal): PR5 sidebar nav groups + fix badge N+1 cache

### DIFF
--- a/app/Filament/Group/Pages/Benchmarking.php
+++ b/app/Filament/Group/Pages/Benchmarking.php
@@ -11,6 +11,8 @@ class Benchmarking extends Page
 
     protected static ?string $navigationLabel = 'Benchmarking';
 
+    protected static ?string $navigationGroup = 'Analytiques';
+
     protected static ?string $title = 'Comparaison des établissements';
 
     protected static ?int $navigationSort = 4;

--- a/app/Filament/Group/Pages/FinancialOverview.php
+++ b/app/Filament/Group/Pages/FinancialOverview.php
@@ -11,6 +11,8 @@ class FinancialOverview extends Page
 
     protected static ?string $navigationLabel = 'Vue Financière';
 
+    protected static ?string $navigationGroup = 'Analytiques';
+
     protected static ?string $title = 'Vue Financière';
 
     protected static ?int $navigationSort = 3;

--- a/app/Filament/Group/Pages/GroupDashboard.php
+++ b/app/Filament/Group/Pages/GroupDashboard.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Group\Pages;
 
+use App\Filament\Group\Resources\EstablishmentResource;
 use App\Services\TenantAggregationService;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
@@ -27,6 +28,7 @@ class GroupDashboard extends Dashboard
                     $group = auth('group')->user()->group;
                     $service = app(TenantAggregationService::class);
                     $service->refreshGroupCache($group);
+                    EstablishmentResource::forgetAlertsCache($group->id);
                     $service->getGroupKpis($group);
 
                     Notification::make()
@@ -41,6 +43,7 @@ class GroupDashboard extends Dashboard
                 ->action(function () {
                     $group = auth('group')->user()->group;
                     Artisan::call('group:alert-check', ['--group' => $group->code]);
+                    EstablishmentResource::forgetAlertsCache($group->id);
 
                     Notification::make()
                         ->title('Alertes vérifiées')

--- a/app/Filament/Group/Resources/EstablishmentResource.php
+++ b/app/Filament/Group/Resources/EstablishmentResource.php
@@ -12,6 +12,7 @@ use Filament\Tables\Table;
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
 
 class EstablishmentResource extends Resource
 {
@@ -27,10 +28,17 @@ class EstablishmentResource extends Resource
 
     protected static ?int $navigationSort = 2;
 
-    /** @var array<int, list<array<string,mixed>>>  memoized per-request alerts keyed by group id */
-    private static array $alertsCache = [];
+    private const ALERTS_CACHE_TTL = 300;
 
-    /** @return list<array<string,mixed>> */
+    private const ALERTS_CACHE_PREFIX = 'group:alerts_v1:';
+
+    /**
+     * Badge alerts read from Cache::remember (5min TTL). Filament calls this on
+     * every render + Livewire poll + 60s notification poll — direct service
+     * hit was an N+1 perf bomb (see PR5 issue #20).
+     *
+     * @return list<array<string,mixed>>
+     */
     private static function currentGroupAlerts(): array
     {
         $group = auth('group')->user()?->group;
@@ -38,17 +46,23 @@ class EstablishmentResource extends Resource
             return [];
         }
 
-        if (isset(self::$alertsCache[$group->id])) {
-            return self::$alertsCache[$group->id];
-        }
+        return Cache::remember(
+            self::ALERTS_CACHE_PREFIX . $group->id,
+            self::ALERTS_CACHE_TTL,
+            static function () use ($group): array {
+                try {
+                    return app(TenantAggregationService::class)
+                        ->getGroupHealthMetrics($group)['alerts'] ?? [];
+                } catch (\Throwable) {
+                    return [];
+                }
+            }
+        );
+    }
 
-        try {
-            return self::$alertsCache[$group->id] =
-                app(TenantAggregationService::class)->getGroupHealthMetrics($group)['alerts'] ?? [];
-        } catch (\Throwable) {
-            // Silent degradation — badge is non-critical.
-            return self::$alertsCache[$group->id] = [];
-        }
+    public static function forgetAlertsCache(int $groupId): void
+    {
+        Cache::forget(self::ALERTS_CACHE_PREFIX . $groupId);
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Http/Controllers/API/TenantCacheInvalidateController.php
+++ b/app/Http/Controllers/API/TenantCacheInvalidateController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Filament\Group\Resources\EstablishmentResource;
 use App\Http\Controllers\Controller;
 use App\Models\Tenant;
 use App\Services\TenantAggregationService;
@@ -32,6 +33,7 @@ class TenantCacheInvalidateController extends Controller
 
         $group = $tenant->group;
         app(TenantAggregationService::class)->refreshGroupCache($group);
+        EstablishmentResource::forgetAlertsCache($group->id);
 
         Log::info("Group cache invalidated for {$code} (group {$group->code})", [
             'triggered_by' => $request->input('trigger', 'unknown'),

--- a/tests/Feature/Group/EstablishmentResourceBadgeCacheTest.php
+++ b/tests/Feature/Group/EstablishmentResourceBadgeCacheTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Filament\Group\Pages\Benchmarking;
+use App\Filament\Group\Pages\FinancialOverview;
+use App\Filament\Group\Resources\EstablishmentResource;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * PR5 — Verify the badge N+1 fix (Cache::remember wrapping) and sidebar
+ * navigation group placement. No DB fixtures needed: the badge method is
+ * guarded by `auth('group')->user()?->group` which short-circuits to `[]`
+ * when nobody is authenticated; we exercise the cache-forget paths in
+ * isolation instead.
+ */
+
+it('alerts cache key includes the group id', function () {
+    $groupId = 42;
+
+    expect(function () use ($groupId) {
+        EstablishmentResource::forgetAlertsCache($groupId);
+    })->not->toThrow(Exception::class);
+
+    // Priming then forgetting leaves the key empty.
+    Cache::put("group:alerts_v1:{$groupId}", [['severity' => 'critical']], 60);
+    expect(Cache::has("group:alerts_v1:{$groupId}"))->toBeTrue();
+
+    EstablishmentResource::forgetAlertsCache($groupId);
+    expect(Cache::has("group:alerts_v1:{$groupId}"))->toBeFalse();
+});
+
+it('forgetAlertsCache of one group does not touch other groups', function () {
+    Cache::put('group:alerts_v1:10', [['severity' => 'warning']], 60);
+    Cache::put('group:alerts_v1:20', [['severity' => 'critical']], 60);
+
+    EstablishmentResource::forgetAlertsCache(10);
+
+    expect(Cache::has('group:alerts_v1:10'))->toBeFalse();
+    expect(Cache::has('group:alerts_v1:20'))->toBeTrue();
+});
+
+it('FinancialOverview lives under the Analytiques navigation group', function () {
+    expect(FinancialOverview::getNavigationGroup())->toBe('Analytiques');
+});
+
+it('Benchmarking lives under the Analytiques navigation group', function () {
+    expect(Benchmarking::getNavigationGroup())->toBe('Analytiques');
+});
+
+it('EstablishmentResource stays top-level (no navigation group)', function () {
+    // Scope guard: grouping the main resource would hide it behind a collapsible
+    // section, hurting discoverability. Must stay top-level.
+    expect(EstablishmentResource::getNavigationGroup())->toBeNull();
+});


### PR DESCRIPTION
## Summary

PR5 portail groupe adminKlassci — scope **minimal additive** post-critic RETHINK sur le plan initial (breadcrumb + switcher + sidebar v2 retirés/différés).

### Fix N+1 perf bomb sur badge alerts (prérequis sécurité perf)

- `EstablishmentResource::currentGroupAlerts()` passait d'un `$alertsCache` **static per-request only** à `Cache::remember('group:alerts_v1:{id}', 300, ...)` cross-request
- Impact éliminé : hit `getGroupHealthMetrics()` à chaque page load + Livewire poll + 60s notification poll → désormais 1 appel service par 5min par groupe
- `forgetAlertsCache(int $groupId)` exposé pour invalidation explicite
- Invalidations hooked : action "Actualiser", action "Vérifier alertes", webhook `TenantCacheInvalidateController` (paiement validé côté tenant)

### Nav groups sidebar (Filament natif)

- **Analytiques** : FinancialOverview + Benchmarking
- Top-level (ungrouped) : Tableau de bord + Établissements
- Filament natif collapsible + cookie-persisted state (pas de localStorage custom, pas de tokens `gp-v2-*`)

## Décisions critic appliquées

**Différé à PR6** (post-verif data ROSTAN) :
- Context switcher tenant — décision UX explicite requise (scope-filter ≠ SSO)

**Ne JAMAIS livrer** :
- Breadcrumb (depth 2 max = bruit pur, Filament montre déjà titre + sidebar highlight)
- Tokens `gp-v2-*` (CSS-over-CSS fragile sur Filament internals)
- localStorage sidebar state (duplique cookie Filament natif)

## Test plan

- [x] 5 nouveaux tests Pest (8 assertions) — 116 total passing
- [x] Visual check `/groupe` : sidebar affiche "Analytiques" collapsible avec Vue Financière + Benchmarking
- [x] Dashboard rend identique (zéro régression)
- [ ] Badge alerts : après action "Actualiser", badge count se met à jour (si alerts changent côté service)
- [ ] Webhook `/api/tenants/{code}/cache/invalidate` : vérifier que la cache badge est bien forget après paiement validé côté tenant