### PR TITLE
chore(group-portal): simplify PR5 post-review

### DIFF
--- a/app/Filament/Group/Resources/EstablishmentResource.php
+++ b/app/Filament/Group/Resources/EstablishmentResource.php
@@ -28,14 +28,22 @@ class EstablishmentResource extends Resource
 
     protected static ?int $navigationSort = 2;
 
+    /**
+     * Must stay <= TenantAggregationService::CACHE_TTL_HEALTH (300s) so the badge
+     * never shows data staler than the service-level cache that backs it.
+     */
     private const ALERTS_CACHE_TTL = 300;
 
     private const ALERTS_CACHE_PREFIX = 'group:alerts_v1:';
 
+    /** @var array<int, list<array<string,mixed>>> per-request memo on top of Cache::remember — kills double Cache driver hit from getNavigationBadge() + getNavigationBadgeColor() */
+    private static array $alertsRequestMemo = [];
+
     /**
-     * Badge alerts read from Cache::remember (5min TTL). Filament calls this on
-     * every render + Livewire poll + 60s notification poll — direct service
-     * hit was an N+1 perf bomb (see PR5 issue #20).
+     * Filament calls this twice per sidebar render (badge count + color) plus
+     * once per Livewire poll and per 60s notification poll. Direct service hits
+     * are an N+1 bomb — we layer a 5-min cross-request cache AND a per-request
+     * memo so a single page render = at most 1 cache driver round-trip.
      *
      * @return list<array<string,mixed>>
      */
@@ -46,7 +54,7 @@ class EstablishmentResource extends Resource
             return [];
         }
 
-        return Cache::remember(
+        return self::$alertsRequestMemo[$group->id] ??= Cache::remember(
             self::ALERTS_CACHE_PREFIX . $group->id,
             self::ALERTS_CACHE_TTL,
             static function () use ($group): array {
@@ -63,6 +71,7 @@ class EstablishmentResource extends Resource
     public static function forgetAlertsCache(int $groupId): void
     {
         Cache::forget(self::ALERTS_CACHE_PREFIX . $groupId);
+        unset(self::$alertsRequestMemo[$groupId]);
     }
 
     public static function getNavigationBadge(): ?string


### PR DESCRIPTION
## Summary

Simplify findings sur PR5 (3 agents parallèles) :

**Appliqués** :
- **Efficiency HIGH** : per-request memo `\$alertsRequestMemo` au-dessus du `Cache::remember` — supprime le double Cache driver round-trip par render (getNavigationBadge + getNavigationBadgeColor appellent tous les deux `currentGroupAlerts`, l'ancien `\$alertsCache` static avait cette optim qui était perdue)
- **Quality** : docblock explicite sur le coupling `ALERTS_CACHE_TTL ≤ CACHE_TTL_HEALTH`
- **Quality** : drop refs PR5 + issue #20 du docblock (refs qui pourrissent)

**Skipped (YAGNI)** :
- Move `forgetAlertsCache` to TenantAggregationService → crée coupling bidirectionnel Filament ↔ Service. 2-of-3 call sites duplication acceptable.
- Constant `'Analytiques'` → 2 occurrences, codebase a déjà 17 nav group strings hardcodées.
- `Cache::lock()` thundering herd → YAGNI à 5-10 users.
- Background stale-while-revalidate → cold hit 1×/5min/groupe acceptable.

## Test plan
- [x] 26 tests passing (Cache + Period suites), zéro régression
- [x] Visual check /groupe : sidebar Analytiques collapsible, tous widgets rendent, aging 5 977 000 F baseline (LSP preserved)