### PR TITLE
chore(group-portal): simplify PR6a post-review

### DIFF
--- a/app/Filament/Group/Pages/GroupDashboard.php
+++ b/app/Filament/Group/Pages/GroupDashboard.php
@@ -48,11 +48,27 @@ class GroupDashboard extends Dashboard
             'group_name' => $group->name ?? 'Mon Groupe',
             'user_name' => $user->name ?? '',
             'role' => self::roleLabel($user->role ?? ''),
-            'establishment_count' => $group?->tenants()->active()->count() ?? 0,
+            'establishment_count' => self::cachedTenantCount($group),
             'academic_years' => self::extractAcademicYears($kpis),
-            'last_sync' => self::lastSyncLabel($user?->group_id),
+            'last_sync' => $group && $service->hasFreshGroupKpis($group)
+                ? 'il y a moins de 15 min'
+                : 'non synchronisé',
             'kpis' => $kpis,
         ];
+    }
+
+    private static function cachedTenantCount(?\App\Models\Group $group): int
+    {
+        if ($group === null) {
+            return 0;
+        }
+
+        // 2 min TTL — avoids a COUNT() query on every Filament render / Livewire poll.
+        return (int) Cache::remember(
+            "group_{$group->id}_tenant_count",
+            120,
+            fn () => $group->tenants()->active()->count()
+        );
     }
 
     private static function roleLabel(string $role): string
@@ -78,17 +94,6 @@ class GroupDashboard extends Dashboard
         return $years;
     }
 
-    private static function lastSyncLabel(?int $groupId): string
-    {
-        if ($groupId === null) {
-            return 'non synchronisé';
-        }
-
-        return Cache::has("group_{$groupId}_kpis")
-            ? 'il y a moins de 15 min'
-            : 'non synchronisé';
-    }
-
     protected function getHeaderActions(): array
     {
         return [
@@ -101,6 +106,7 @@ class GroupDashboard extends Dashboard
                     $service = app(TenantAggregationService::class);
                     $service->refreshGroupCache($group);
                     EstablishmentResource::forgetAlertsCache($group->id);
+                    Cache::forget("group_{$group->id}_tenant_count");
                     $service->getGroupKpis($group);
 
                     Notification::make()

--- a/app/Services/TenantAggregationService.php
+++ b/app/Services/TenantAggregationService.php
@@ -62,6 +62,13 @@ class TenantAggregationService
         return self::CACHE_KEY_PREFIX . "_{$groupId}_{$suffix}_{$period->cacheKey()}";
     }
 
+    public function hasFreshGroupKpis(Group $group, ?PeriodInterface $period = null): bool
+    {
+        $period ??= PeriodFactory::default();
+
+        return Cache::has($this->cacheKey($group->id, 'kpis', $period));
+    }
+
     public function getGroupKpis(Group $group, ?PeriodInterface $period = null): array
     {
         $period ??= PeriodFactory::default();

--- a/app/Support/FcfaFormatter.php
+++ b/app/Support/FcfaFormatter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Shared FCFA amount formatting for group portal UI. Kept as static helpers
+ * to avoid container resolution in Blade views and keep call sites terse.
+ */
+final class FcfaFormatter
+{
+    /**
+     * Compact thousands/millions notation — e.g. `1 234 567` → `1,2 M`,
+     * `750_000` → `750 k`, `50` → `50`. Use in hero KPIs where space is tight.
+     */
+    public static function compact(float $amount): string
+    {
+        if ($amount >= 1_000_000) {
+            return number_format($amount / 1_000_000, 1, ',', ' ') . ' M';
+        }
+
+        if ($amount >= 1_000) {
+            return number_format($amount / 1_000, 0, ',', ' ') . ' k';
+        }
+
+        return number_format($amount, 0, ',', ' ');
+    }
+
+    /**
+     * Millions-only, e.g. `1 234 567` → `1,2 M`. Use when the caller already
+     * knows the amount is in the millions (KPI tables).
+     */
+    public static function millions(float $amount): string
+    {
+        return number_format($amount / 1_000_000, 1, ',', ' ');
+    }
+
+    /** Full formatted amount with thin-space thousand separator: `1 234 567`. */
+    public static function full(float $amount): string
+    {
+        return number_format($amount, 0, ',', ' ');
+    }
+}

--- a/app/View/Components/GroupHero.php
+++ b/app/View/Components/GroupHero.php
@@ -6,15 +6,13 @@ use Illuminate\View\Component;
 use Illuminate\View\View;
 
 /**
- * Premium hero component used across group portal pages (Dashboard,
- * FinancialOverview, Benchmarking, Establishment views).
+ * Premium hero used across group portal pages. CSS lives in `gp-hero-*`
+ * (public/css/groupe-portal.css).
  *
- * Namespaced under the existing `gp-*` CSS family — no new token family.
- *
- * Slots :
- *   actions — buttons on the right of row 1 (glass / white)
- *   kpis    — 4-6 KPI cards in row 2 (glass background, see .gp-hero-kpi)
- *   badges  — small badges under the title (period chip, status, etc.)
+ * Slots:
+ *   actions — buttons on the right of row 1
+ *   kpis    — 4-6 KPI cards in row 2 (glass, see .gp-hero-kpi)
+ *   badges  — chips/badges under the subtitle
  */
 class GroupHero extends Component
 {

--- a/resources/views/filament/group/partials/dashboard-hero.blade.php
+++ b/resources/views/filament/group/partials/dashboard-hero.blade.php
@@ -10,17 +10,13 @@
      *     kpis: array<string,mixed>,
      * } $context
      */
+    use App\Support\FcfaFormatter;
+
     $k = $context['kpis'];
     $totalStudents = (int) ($k['total_students'] ?? 0);
     $collectionRate = (float) ($k['collection_rate'] ?? 0);
     $revenueCollected = (float) ($k['total_revenue_collected'] ?? 0);
     $establishmentCount = $context['establishment_count'];
-
-    $formatNumber = fn (float $n): string => number_format($n, 0, ',', ' ');
-    $formatFcfa = fn (float $n): string => $n >= 1_000_000
-        ? number_format($n / 1_000_000, 1, ',', ' ') . ' M'
-        : number_format($n / 1_000, 0, ',', ' ') . ' k';
-
     $recoveryColor = $collectionRate >= 70 ? 'success' : ($collectionRate >= 50 ? 'warning' : 'danger');
 @endphp
 
@@ -49,19 +45,19 @@
     <x-slot:kpis>
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Étudiants inscrits</span>
-            <span class="gp-hero-kpi-value">{{ $formatNumber($totalStudents) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full($totalStudents) }}</span>
             <span class="gp-hero-kpi-meta">{{ $establishmentCount }} {{ \Illuminate\Support\Str::plural('établissement', $establishmentCount) }}</span>
         </div>
 
         <div class="gp-hero-kpi" data-tone="{{ $recoveryColor }}">
             <span class="gp-hero-kpi-label">Recouvrement</span>
             <span class="gp-hero-kpi-value">{{ number_format($collectionRate, 1, ',', ' ') }}&nbsp;%</span>
-            <span class="gp-hero-kpi-meta">{{ $formatFcfa($revenueCollected) }} FCFA encaissés</span>
+            <span class="gp-hero-kpi-meta">{{ FcfaFormatter::compact($revenueCollected) }} FCFA encaissés</span>
         </div>
 
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Personnel</span>
-            <span class="gp-hero-kpi-value">{{ $formatNumber((float) ($k['total_staff'] ?? 0)) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) ($k['total_staff'] ?? 0)) }}</span>
             <span class="gp-hero-kpi-meta">membres cross-groupe</span>
         </div>
 

--- a/tests/Feature/Group/DashboardHeroTest.php
+++ b/tests/Feature/Group/DashboardHeroTest.php
@@ -3,9 +3,9 @@
 use App\View\Components\GroupHero;
 
 /**
- * PR6a — Dashboard hero structural tests. Behavior under a real authenticated
- * group member is covered by visual check / Playwright; here we pin the Blade
- * component contract and the header wiring on GroupDashboard.
+ * Structural tests pinning the Blade component contract + the header wiring
+ * on GroupDashboard. Behavior under a real authenticated group member is
+ * covered by visual check / Playwright.
  */
 
 it('GroupHero component has required props', function () {
@@ -42,7 +42,7 @@ it('GroupDashboard provides hero context with expected keys', function () {
     expect($reflection->getMethod('getHeroContext')->isPrivate())->toBeTrue();
 });
 
-it('GroupWelcomeWidget has been retired (PR6a)', function () {
+it('GroupWelcomeWidget has been retired — hero lives at the page level', function () {
     // Check the file, not the class — composer autoload caches can lag in test envs.
     expect(file_exists(app_path('Filament/Group/Widgets/GroupWelcomeWidget.php')))
         ->toBeFalse('GroupWelcomeWidget.php should be removed — hero lives at the page level now');
@@ -58,8 +58,49 @@ it('GroupDashboard does not register GroupWelcomeWidget', function () {
     expect($source)->not->toContain('GroupWelcomeWidget');
 });
 
-it('dashboard-hero partial renders without error given a valid context shape', function () {
-    $context = [
+it('dashboard-hero partial renders the happy path', function () {
+    $context = makeHeroContext();
+
+    $html = view('filament.group.partials.dashboard-hero', compact('context'))->render();
+
+    expect($html)->toContain('Test Group');
+    expect($html)->toContain('Jane Doe');
+    expect($html)->toContain('Fondateur');
+    expect($html)->toContain('1 234');
+    expect($html)->toContain('72,5');
+    expect($html)->toContain('Portail Groupe');
+});
+
+it('hides academic-year chip when no years are available', function () {
+    $context = makeHeroContext(['academic_years' => []]);
+
+    $html = view('filament.group.partials.dashboard-hero', compact('context'))->render();
+
+    expect($html)->not->toContain('2025-2026');
+});
+
+it('applies danger tone when collection rate is below 50%', function () {
+    $context = makeHeroContext(['kpis' => ['collection_rate' => 12.0] + makeHeroContext()['kpis']]);
+
+    $html = view('filament.group.partials.dashboard-hero', compact('context'))->render();
+
+    expect($html)->toContain('data-tone="danger"');
+});
+
+it('uses singular "établissement" when count is 1', function () {
+    $context = makeHeroContext(['establishment_count' => 1]);
+
+    $html = view('filament.group.partials.dashboard-hero', compact('context'))->render();
+
+    expect($html)->toContain('1 établissement');
+    expect($html)->not->toContain('1 établissements');
+});
+
+function makeHeroContext(array $overrides = []): array
+{
+    // array_replace (not recursive) so overriding `academic_years` with an
+    // empty list actually empties it instead of merging.
+    return array_replace([
         'group_name' => 'Test Group',
         'user_name' => 'Jane Doe',
         'role' => 'Fondateur',
@@ -73,14 +114,5 @@ it('dashboard-hero partial renders without error given a valid context shape', f
             'total_staff' => 45,
             'avg_attendance_rate' => 88.3,
         ],
-    ];
-
-    $html = view('filament.group.partials.dashboard-hero', compact('context'))->render();
-
-    expect($html)->toContain('Test Group');
-    expect($html)->toContain('Jane Doe');
-    expect($html)->toContain('Fondateur');
-    expect($html)->toContain('1 234');   // thousand-sep
-    expect($html)->toContain('72,5');     // FR decimal
-    expect($html)->toContain('Portail Groupe');
-});
+    ], $overrides);
+}

--- a/tests/Unit/Support/FcfaFormatterTest.php
+++ b/tests/Unit/Support/FcfaFormatterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Support\FcfaFormatter;
+
+it('formats amounts below 1000 without prefix', function () {
+    expect(FcfaFormatter::compact(0))->toBe('0');
+    expect(FcfaFormatter::compact(50))->toBe('50');
+    expect(FcfaFormatter::compact(999))->toBe('999');
+});
+
+it('formats thousands with k suffix', function () {
+    expect(FcfaFormatter::compact(1_000))->toBe('1 k');
+    expect(FcfaFormatter::compact(43_000))->toBe('43 k');
+    expect(FcfaFormatter::compact(750_000))->toBe('750 k');
+});
+
+it('formats millions with M suffix and 1 decimal', function () {
+    expect(FcfaFormatter::compact(1_000_000))->toBe('1,0 M');
+    expect(FcfaFormatter::compact(12_500_000))->toBe('12,5 M');
+    expect(FcfaFormatter::compact(4_607_000))->toBe('4,6 M');
+});
+
+it('millions() always divides by 1_000_000', function () {
+    expect(FcfaFormatter::millions(5_977_000))->toBe('6,0');
+    expect(FcfaFormatter::millions(1_370_000))->toBe('1,4');
+});
+
+it('full() keeps thin-space thousand separator', function () {
+    expect(FcfaFormatter::full(0))->toBe('0');
+    expect(FcfaFormatter::full(1_234_567))->toBe('1 234 567');
+    expect(FcfaFormatter::full(43_000))->toBe('43 000');
+});


### PR DESCRIPTION
## Summary

3 agents review findings fixés :

**HIGH BUG** — \`lastSyncLabel\` retournait toujours 'non synchronisé' (cache key mismatch : vérifiait \`group_{id}_kpis\` alors que le service écrit \`group_v2_{id}_kpis_{period}\` depuis PR4a). Nouveau \`TenantAggregationService::hasFreshGroupKpis()\` qui utilise le bon format.

**HIGH perf** — \`tenants()->active()->count()\` sur chaque getHeader() → \`Cache::remember\` 2min TTL + invalidation dans action 'Actualiser'.

**HIGH reuse** — FCFA formatter dupliqué 3× → extrait en \`App\Support\FcfaFormatter\` (compact/millions/full).

**MEDIUM** — drop refs PR6a, 3 edge case tests (empty years, danger tone, singular pluriel).

**Skipped YAGNI** — heroicon lib (reporté PR6b), KPI duplication (design), chip/badge consolidation.

## Test plan

- [x] 129 tests passing (+8 vs PR6a merge), zéro régression
- [x] FcfaFormatter : 5 unit tests
- [x] DashboardHero : 3 edge cases