### PR TITLE
feat(group-portal): PR6c premium hero EstablishmentResource list + view

### DIFF
--- a/app/Filament/Group/Resources/EstablishmentResource/Pages/ListEstablishments.php
+++ b/app/Filament/Group/Resources/EstablishmentResource/Pages/ListEstablishments.php
@@ -3,11 +3,41 @@
 namespace App\Filament\Group\Resources\EstablishmentResource\Pages;
 
 use App\Filament\Group\Resources\EstablishmentResource;
+use App\Services\TenantAggregationService;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\View\View;
 
 class ListEstablishments extends ListRecords
 {
     protected static string $resource = EstablishmentResource::class;
 
     protected static ?string $title = 'Mes Établissements';
+
+    public function getHeader(): ?View
+    {
+        return view('filament.group.partials.establishments-hero', [
+            'context' => $this->buildHeroContext(),
+        ]);
+    }
+
+    public function getHeading(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return array{total_students: int, total_staff: int, establishment_count: int, avg_rate: float}
+     */
+    private function buildHeroContext(): array
+    {
+        $group = auth('group')->user()?->group;
+        $kpis = $group ? app(TenantAggregationService::class)->getGroupKpis($group) : [];
+
+        return [
+            'total_students' => (int) ($kpis['total_students'] ?? 0),
+            'total_staff' => (int) ($kpis['total_staff'] ?? 0),
+            'establishment_count' => (int) ($kpis['establishment_count'] ?? 0),
+            'avg_rate' => (float) ($kpis['collection_rate'] ?? 0),
+        ];
+    }
 }

--- a/app/Filament/Group/Resources/EstablishmentResource/Pages/ViewEstablishment.php
+++ b/app/Filament/Group/Resources/EstablishmentResource/Pages/ViewEstablishment.php
@@ -3,11 +3,36 @@
 namespace App\Filament\Group\Resources\EstablishmentResource\Pages;
 
 use App\Filament\Group\Resources\EstablishmentResource;
+use App\Services\TenantAggregationService;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Contracts\View\View;
 
 class ViewEstablishment extends ViewRecord
 {
     protected static string $resource = EstablishmentResource::class;
 
     protected static ?string $title = 'Détail Établissement';
+
+    public function getHeader(): ?View
+    {
+        return view('filament.group.partials.establishment-view-hero', [
+            'tenant' => $this->record,
+            'kpis' => $this->buildTenantKpis(),
+        ]);
+    }
+
+    public function getHeading(): string
+    {
+        return '';
+    }
+
+    /** @return array<string,mixed> */
+    private function buildTenantKpis(): array
+    {
+        try {
+            return app(TenantAggregationService::class)->getTenantKpis($this->record);
+        } catch (\Throwable) {
+            return [];
+        }
+    }
 }

--- a/public/css/groupe-portal.css
+++ b/public/css/groupe-portal.css
@@ -146,6 +146,28 @@
     gap: 0.5rem;
     flex-wrap: wrap;
 }
+.gp-hero-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 1.1rem;
+    background: #fff;
+    color: var(--gp-primary);
+    border-radius: 9999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform .15s ease, box-shadow .15s ease;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+.gp-hero-action:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+}
+.gp-hero-action svg {
+    width: 1rem;
+    height: 1rem;
+}
 .gp-hero-kpis {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/resources/views/filament/group/partials/establishment-view-hero.blade.php
+++ b/resources/views/filament/group/partials/establishment-view-hero.blade.php
@@ -1,0 +1,77 @@
+@php use App\Support\FcfaFormatter; @endphp
+
+@php
+    /** @var \App\Models\Tenant $tenant */
+    /** @var array<string,mixed> $kpis */
+    $students = (int) ($kpis['students'] ?? $kpis['inscriptions'] ?? 0);
+    $staff = (int) ($kpis['staff'] ?? 0);
+    $rate = (float) ($kpis['collection_rate'] ?? 0);
+    $rateColor = $rate >= 70 ? 'success' : ($rate >= 50 ? 'warning' : 'danger');
+    $academicYear = $kpis['academic_year'] ?? 'N/A';
+
+    $statusLabel = match ($tenant->status ?? '') {
+        'active' => 'Actif',
+        'suspended' => 'Suspendu',
+        'maintenance' => 'Maintenance',
+        default => ucfirst((string) ($tenant->status ?? 'inconnu')),
+    };
+    $statusTone = match ($tenant->status ?? '') {
+        'active' => 'success',
+        'suspended' => 'warning',
+        'maintenance' => 'warning',
+        default => 'danger',
+    };
+@endphp
+
+<x-group-hero
+    :title="$tenant->name"
+    :subtitle="($tenant->code ?? '') . ' · Plan ' . ucfirst((string) ($tenant->plan ?? 'n/a'))"
+    icon-path="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"
+>
+    <x-slot:badges>
+        <span class="gp-hero-chip">{{ $statusLabel }}</span>
+        @if(! empty($tenant->subdomain))
+            <span class="gp-hero-chip">{{ $tenant->subdomain }}.klassci.com</span>
+        @endif
+    </x-slot:badges>
+
+    <x-slot:actions>
+        @if(($tenant->status ?? '') === 'active' && ! empty($tenant->subdomain))
+            <a href="https://{{ $tenant->subdomain }}.klassci.com"
+               target="_blank"
+               rel="noopener"
+               class="gp-hero-action">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"/>
+                </svg>
+                Ouvrir l'établissement
+            </a>
+        @endif
+    </x-slot:actions>
+
+    <x-slot:kpis>
+        <div class="gp-hero-kpi">
+            <span class="gp-hero-kpi-label">Étudiants inscrits</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $students) }}</span>
+            <span class="gp-hero-kpi-meta">année en cours</span>
+        </div>
+
+        <div class="gp-hero-kpi">
+            <span class="gp-hero-kpi-label">Personnel</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $staff) }}</span>
+            <span class="gp-hero-kpi-meta">membres actifs</span>
+        </div>
+
+        <div class="gp-hero-kpi" data-tone="{{ $rateColor }}">
+            <span class="gp-hero-kpi-label">Recouvrement</span>
+            <span class="gp-hero-kpi-value">{{ number_format($rate, 1, ',', ' ') }}&nbsp;%</span>
+            <span class="gp-hero-kpi-meta">{{ $rate >= 70 ? 'sain' : ($rate >= 50 ? 'à surveiller' : 'critique') }}</span>
+        </div>
+
+        <div class="gp-hero-kpi">
+            <span class="gp-hero-kpi-label">Année universitaire</span>
+            <span class="gp-hero-kpi-value" style="font-size: 1.15rem;">{{ $academicYear }}</span>
+            <span class="gp-hero-kpi-meta">synchro {{ $statusTone === 'success' ? 'temps réel' : 'différée' }}</span>
+        </div>
+    </x-slot:kpis>
+</x-group-hero>

--- a/resources/views/filament/group/partials/establishments-hero.blade.php
+++ b/resources/views/filament/group/partials/establishments-hero.blade.php
@@ -1,0 +1,43 @@
+@php use App\Support\FcfaFormatter; @endphp
+
+@php
+    /** @var array{total_students:int,total_staff:int,establishment_count:int,avg_rate:float} $context */
+    $rate = (float) $context['avg_rate'];
+    $rateColor = $rate >= 70 ? 'success' : ($rate >= 50 ? 'warning' : 'danger');
+@endphp
+
+<x-group-hero
+    title="Mes Établissements"
+    subtitle="Pilotage centralisé des établissements du groupe"
+    icon-path="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z"
+>
+    <x-slot:badges>
+        <span class="gp-hero-chip">{{ $context['establishment_count'] }} {{ \Illuminate\Support\Str::plural('établissement', $context['establishment_count']) }}</span>
+    </x-slot:badges>
+
+    <x-slot:kpis>
+        <div class="gp-hero-kpi">
+            <span class="gp-hero-kpi-label">Étudiants inscrits</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $context['total_students']) }}</span>
+            <span class="gp-hero-kpi-meta">cumul cross-groupe</span>
+        </div>
+
+        <div class="gp-hero-kpi">
+            <span class="gp-hero-kpi-label">Personnel</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $context['total_staff']) }}</span>
+            <span class="gp-hero-kpi-meta">membres actifs</span>
+        </div>
+
+        <div class="gp-hero-kpi">
+            <span class="gp-hero-kpi-label">Établissements</span>
+            <span class="gp-hero-kpi-value">{{ $context['establishment_count'] }}</span>
+            <span class="gp-hero-kpi-meta">sous pilotage</span>
+        </div>
+
+        <div class="gp-hero-kpi" data-tone="{{ $rateColor }}">
+            <span class="gp-hero-kpi-label">Recouvrement moyen</span>
+            <span class="gp-hero-kpi-value">{{ number_format($rate, 1, ',', ' ') }}&nbsp;%</span>
+            <span class="gp-hero-kpi-meta">{{ $rate >= 70 ? 'sain' : ($rate >= 50 ? 'à surveiller' : 'critique') }}</span>
+        </div>
+    </x-slot:kpis>
+</x-group-hero>

--- a/tests/Feature/Group/EstablishmentHeroTest.php
+++ b/tests/Feature/Group/EstablishmentHeroTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Filament\Group\Resources\EstablishmentResource\Pages\ListEstablishments;
+use App\Filament\Group\Resources\EstablishmentResource\Pages\ViewEstablishment;
+
+it('ListEstablishments declares a custom header + empty heading', function () {
+    $reflection = new ReflectionClass(ListEstablishments::class);
+
+    expect($reflection->hasMethod('getHeader'))->toBeTrue();
+    expect($reflection->hasMethod('getHeading'))->toBeTrue();
+    expect($reflection->hasMethod('buildHeroContext'))->toBeTrue();
+});
+
+it('ViewEstablishment declares a custom header + empty heading', function () {
+    $reflection = new ReflectionClass(ViewEstablishment::class);
+
+    expect($reflection->hasMethod('getHeader'))->toBeTrue();
+    expect($reflection->hasMethod('getHeading'))->toBeTrue();
+});
+
+it('establishments-hero partial renders happy path', function () {
+    $html = view('filament.group.partials.establishments-hero', [
+        'context' => [
+            'total_students' => 120,
+            'total_staff' => 18,
+            'establishment_count' => 2,
+            'avg_rate' => 75.5,
+        ],
+    ])->render();
+
+    expect($html)->toContain('Mes Établissements');
+    expect($html)->toContain('120');
+    expect($html)->toContain('75,5');
+    expect($html)->toContain('data-tone="success"');
+});
+
+it('establishments-hero uses singular form when count = 1', function () {
+    $html = view('filament.group.partials.establishments-hero', [
+        'context' => [
+            'total_students' => 12,
+            'total_staff' => 8,
+            'establishment_count' => 1,
+            'avg_rate' => 50.0,
+        ],
+    ])->render();
+
+    expect($html)->toContain('1 établissement');
+    expect($html)->not->toContain('1 établissements');
+});
+
+it('establishment-view-hero partial renders happy path', function () {
+    $tenant = new \App\Models\Tenant();
+    $tenant->name = 'ROSTAN Abidjan';
+    $tenant->code = 'rostan';
+    $tenant->plan = 'professional';
+    $tenant->status = 'active';
+    $tenant->subdomain = 'rostan';
+
+    $html = view('filament.group.partials.establishment-view-hero', [
+        'tenant' => $tenant,
+        'kpis' => [
+            'students' => 12,
+            'staff' => 8,
+            'collection_rate' => 9.9,
+            'academic_year' => '2025-2026',
+        ],
+    ])->render();
+
+    expect($html)->toContain('ROSTAN Abidjan');
+    expect($html)->toContain('rostan · Plan Professional');
+    expect($html)->toContain('Actif');
+    expect($html)->toContain('data-tone="danger"');
+    expect($html)->toContain('rostan.klassci.com');
+});
+
+it('establishment-view-hero omits the SSO button when tenant is suspended', function () {
+    $tenant = new \App\Models\Tenant();
+    $tenant->name = 'Test';
+    $tenant->code = 'test';
+    $tenant->plan = 'free';
+    $tenant->status = 'suspended';
+    $tenant->subdomain = 'test';
+
+    $html = view('filament.group.partials.establishment-view-hero', [
+        'tenant' => $tenant,
+        'kpis' => [],
+    ])->render();
+
+    expect($html)->toContain('Suspendu');
+    expect($html)->not->toContain("Ouvrir l'établissement");
+    expect($html)->not->toContain('https://test.klassci.com');
+});


### PR DESCRIPTION
Phase 3/3 final du redesign portail groupe.

**/groupe/establishments** — hero `<x-group-hero>` via `getHeader()` + 4 KPIs (Étudiants, Personnel, Établissements, Recouvrement). Table Filament native conservée.

**/groupe/establishments/{id}** — hero avec nom tenant + chips status/URL + action SSO (conditionnelle active) + 4 KPIs. Infolist 5 sections intact.

139 tests passing (+6), zéro régression.

**Les 6 pages /groupe sont désormais premium** : Dashboard, Établissements list/view, Vue Financière, Benchmarking. EditProfile reste standard (rule premium-redesign interdit hero sur forms).

Closes #29