### PR TITLE
chore(group-portal): simplify PR6b + PR6c post-review

### DIFF
--- a/app/Filament/Group/Concerns/HasCustomHero.php
+++ b/app/Filament/Group/Concerns/HasCustomHero.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Group\Concerns;
+
+/**
+ * Suppresses Filament's default page heading + subheading rendering so a
+ * custom hero (rendered via `getHeader()` on the page) is the only title
+ * visible.
+ *
+ * Applied to every group-portal page that ships a `<x-group-hero>` — without
+ * this trait Filament renders its own `<h1>` above the hero, causing a
+ * visible duplicate.
+ */
+trait HasCustomHero
+{
+    public function getHeading(): string
+    {
+        return '';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return null;
+    }
+}

--- a/app/Filament/Group/Pages/Benchmarking.php
+++ b/app/Filament/Group/Pages/Benchmarking.php
@@ -2,11 +2,14 @@
 
 namespace App\Filament\Group\Pages;
 
+use App\Filament\Group\Concerns\HasCustomHero;
 use App\Services\TenantAggregationService;
 use Filament\Pages\Page;
 
 class Benchmarking extends Page
 {
+    use HasCustomHero;
+
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
 
     protected static ?string $navigationLabel = 'Benchmarking';
@@ -18,17 +21,6 @@ class Benchmarking extends Page
     protected static ?int $navigationSort = 4;
 
     protected static string $view = 'filament.group.pages.benchmarking';
-
-    /** Hero custom affiche le titre — Filament ne doit pas le répéter. */
-    public function getHeading(): string
-    {
-        return '';
-    }
-
-    public function getSubheading(): ?string
-    {
-        return null;
-    }
 
     public function getComparisonData(): array
     {

--- a/app/Filament/Group/Pages/FinancialOverview.php
+++ b/app/Filament/Group/Pages/FinancialOverview.php
@@ -2,11 +2,14 @@
 
 namespace App\Filament\Group\Pages;
 
+use App\Filament\Group\Concerns\HasCustomHero;
 use App\Services\TenantAggregationService;
 use Filament\Pages\Page;
 
 class FinancialOverview extends Page
 {
+    use HasCustomHero;
+
     protected static ?string $navigationIcon = 'heroicon-o-banknotes';
 
     protected static ?string $navigationLabel = 'Vue Financière';
@@ -18,17 +21,6 @@ class FinancialOverview extends Page
     protected static ?int $navigationSort = 3;
 
     protected static string $view = 'filament.group.pages.financial-overview';
-
-    /** Hero custom affiche le titre — Filament ne doit pas le répéter. */
-    public function getHeading(): string
-    {
-        return '';
-    }
-
-    public function getSubheading(): ?string
-    {
-        return null;
-    }
 
     public function getFinancials(): array
     {

--- a/app/Filament/Group/Pages/GroupDashboard.php
+++ b/app/Filament/Group/Pages/GroupDashboard.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Group\Pages;
 
+use App\Filament\Group\Concerns\HasCustomHero;
 use App\Filament\Group\Resources\EstablishmentResource;
 use App\Services\TenantAggregationService;
 use Filament\Actions\Action;
@@ -13,6 +14,8 @@ use Illuminate\Support\Facades\Cache;
 
 class GroupDashboard extends Dashboard
 {
+    use HasCustomHero;
+
     protected static ?string $navigationIcon = 'heroicon-o-building-office-2';
 
     protected static ?string $title = 'Tableau de bord';
@@ -24,12 +27,6 @@ class GroupDashboard extends Dashboard
         return view('filament.group.partials.dashboard-hero', [
             'context' => $this->getHeroContext(),
         ]);
-    }
-
-    /** Hero custom affiche le titre — Filament ne doit pas le répéter. */
-    public function getHeading(): string
-    {
-        return '';
     }
 
     /**

--- a/app/Filament/Group/Resources/EstablishmentResource/Pages/ListEstablishments.php
+++ b/app/Filament/Group/Resources/EstablishmentResource/Pages/ListEstablishments.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Group\Resources\EstablishmentResource\Pages;
 
+use App\Filament\Group\Concerns\HasCustomHero;
 use App\Filament\Group\Resources\EstablishmentResource;
 use App\Services\TenantAggregationService;
 use Filament\Resources\Pages\ListRecords;
@@ -9,6 +10,8 @@ use Illuminate\Contracts\View\View;
 
 class ListEstablishments extends ListRecords
 {
+    use HasCustomHero;
+
     protected static string $resource = EstablishmentResource::class;
 
     protected static ?string $title = 'Mes Établissements';
@@ -18,11 +21,6 @@ class ListEstablishments extends ListRecords
         return view('filament.group.partials.establishments-hero', [
             'context' => $this->buildHeroContext(),
         ]);
-    }
-
-    public function getHeading(): string
-    {
-        return '';
     }
 
     /**

--- a/app/Filament/Group/Resources/EstablishmentResource/Pages/ViewEstablishment.php
+++ b/app/Filament/Group/Resources/EstablishmentResource/Pages/ViewEstablishment.php
@@ -2,13 +2,17 @@
 
 namespace App\Filament\Group\Resources\EstablishmentResource\Pages;
 
+use App\Filament\Group\Concerns\HasCustomHero;
 use App\Filament\Group\Resources\EstablishmentResource;
 use App\Services\TenantAggregationService;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Cache;
 
 class ViewEstablishment extends ViewRecord
 {
+    use HasCustomHero;
+
     protected static string $resource = EstablishmentResource::class;
 
     protected static ?string $title = 'Détail Établissement';
@@ -21,18 +25,21 @@ class ViewEstablishment extends ViewRecord
         ]);
     }
 
-    public function getHeading(): string
-    {
-        return '';
-    }
-
     /** @return array<string,mixed> */
     private function buildTenantKpis(): array
     {
-        try {
-            return app(TenantAggregationService::class)->getTenantKpis($this->record);
-        } catch (\Throwable) {
-            return [];
-        }
+        // Short-TTL cache on the error path so a down tenant DB doesn't
+        // re-trigger a schema-aware query on every 15s Livewire poll.
+        return Cache::remember(
+            "group_portal_tenant_kpis_{$this->record->id}",
+            60,
+            function (): array {
+                try {
+                    return app(TenantAggregationService::class)->getTenantKpis($this->record);
+                } catch (\Throwable) {
+                    return [];
+                }
+            }
+        );
     }
 }

--- a/app/Support/FcfaFormatter.php
+++ b/app/Support/FcfaFormatter.php
@@ -39,4 +39,10 @@ final class FcfaFormatter
     {
         return number_format($amount, 0, ',', ' ');
     }
+
+    /** Integer count with thin-space thousand separator: `1 234`. Use for student/staff counts, not money. */
+    public static function integer(int $count): string
+    {
+        return number_format($count, 0, ',', ' ');
+    }
 }

--- a/app/Support/RateHealth.php
+++ b/app/Support/RateHealth.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Maps a collection / attendance rate (0-100) to a semantic tone and a
+ * French health label used across group portal hero KPIs.
+ *
+ * Centralizing these thresholds means the directrice can tweak them in one
+ * place — changing `HEALTHY` from 70 to 75 stays a one-line edit and can't
+ * silently drift between the dashboard, financial overview, benchmarking,
+ * and establishment pages.
+ */
+final class RateHealth
+{
+    public const HEALTHY = 70.0;
+    public const AT_RISK = 50.0;
+
+    /** Returns one of: 'success' | 'warning' | 'danger'. Maps to `.gp-hero-kpi[data-tone]`. */
+    public static function tone(float $rate): string
+    {
+        return match (true) {
+            $rate >= self::HEALTHY => 'success',
+            $rate >= self::AT_RISK => 'warning',
+            default => 'danger',
+        };
+    }
+
+    /** French health label displayed under a rate KPI. */
+    public static function label(float $rate): string
+    {
+        return match (true) {
+            $rate >= self::HEALTHY => 'sain',
+            $rate >= self::AT_RISK => 'à surveiller',
+            default => 'critique',
+        };
+    }
+}

--- a/resources/views/filament/group/pages/benchmarking.blade.php
+++ b/resources/views/filament/group/pages/benchmarking.blade.php
@@ -1,4 +1,4 @@
-@php use App\Support\FcfaFormatter; @endphp
+@php use App\Support\FcfaFormatter; use App\Support\RateHealth; @endphp
 <x-filament-panels::page>
     @php
         $establishments = $this->getComparisonData();
@@ -21,7 +21,6 @@
         }
         $avgRate = $rateCount > 0 ? $rateSum / $rateCount : 0;
         $avgRatio = $totalStaff > 0 ? round($totalInscriptions / $totalStaff, 1) : 0;
-        $avgRateColor = $avgRate >= 70 ? 'success' : ($avgRate >= 50 ? 'warning' : 'danger');
     @endphp
 
     <x-group-hero
@@ -36,20 +35,20 @@
         <x-slot:kpis>
             <div class="gp-hero-kpi">
                 <span class="gp-hero-kpi-label">Étudiants total</span>
-                <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $totalInscriptions) }}</span>
+                <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($totalInscriptions) }}</span>
                 <span class="gp-hero-kpi-meta">cumul du groupe</span>
             </div>
 
             <div class="gp-hero-kpi">
                 <span class="gp-hero-kpi-label">Personnel total</span>
-                <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $totalStaff) }}</span>
+                <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($totalStaff) }}</span>
                 <span class="gp-hero-kpi-meta">ratio {{ $avgRatio }}:1</span>
             </div>
 
-            <div class="gp-hero-kpi" data-tone="{{ $avgRateColor }}">
+            <div class="gp-hero-kpi" data-tone="{{ RateHealth::tone($avgRate) }}">
                 <span class="gp-hero-kpi-label">Taux moyen recouvrement</span>
                 <span class="gp-hero-kpi-value">{{ number_format($avgRate, 1, ',', ' ') }}&nbsp;%</span>
-                <span class="gp-hero-kpi-meta">moyenne simple</span>
+                <span class="gp-hero-kpi-meta">{{ RateHealth::label($avgRate) }}</span>
             </div>
 
             <div class="gp-hero-kpi" data-tone="success">

--- a/resources/views/filament/group/pages/financial-overview.blade.php
+++ b/resources/views/filament/group/pages/financial-overview.blade.php
@@ -1,10 +1,9 @@
-@php use App\Support\FcfaFormatter; @endphp
+@php use App\Support\FcfaFormatter; use App\Support\RateHealth; @endphp
 <x-filament-panels::page>
     @php
         $financials = $this->getFinancials();
         $totals = $this->getTotals();
         $rate = (float) ($totals['rate'] ?? 0);
-        $rateColor = $rate >= 70 ? 'success' : ($rate >= 50 ? 'warning' : 'danger');
         $outstanding = (float) ($totals['outstanding'] ?? 0);
         $surplus = (float) ($totals['surplus'] ?? 0);
     @endphp
@@ -38,10 +37,10 @@
                 <span class="gp-hero-kpi-meta">{{ $outstanding > 0 ? 'à recouvrer' : 'trop-perçu' }}</span>
             </div>
 
-            <div class="gp-hero-kpi" data-tone="{{ $rateColor }}">
+            <div class="gp-hero-kpi" data-tone="{{ RateHealth::tone($rate) }}">
                 <span class="gp-hero-kpi-label">Taux de recouvrement</span>
                 <span class="gp-hero-kpi-value">{{ number_format($rate, 1, ',', ' ') }}&nbsp;%</span>
-                <span class="gp-hero-kpi-meta">{{ $rate >= 70 ? 'sain' : ($rate >= 50 ? 'à surveiller' : 'critique') }}</span>
+                <span class="gp-hero-kpi-meta">{{ RateHealth::label($rate) }}</span>
             </div>
         </x-slot:kpis>
     </x-group-hero>

--- a/resources/views/filament/group/partials/dashboard-hero.blade.php
+++ b/resources/views/filament/group/partials/dashboard-hero.blade.php
@@ -1,3 +1,5 @@
+@php use App\Support\FcfaFormatter; use App\Support\RateHealth; @endphp
+
 @php
     /**
      * @var array{
@@ -10,14 +12,11 @@
      *     kpis: array<string,mixed>,
      * } $context
      */
-    use App\Support\FcfaFormatter;
-
     $k = $context['kpis'];
     $totalStudents = (int) ($k['total_students'] ?? 0);
     $collectionRate = (float) ($k['collection_rate'] ?? 0);
     $revenueCollected = (float) ($k['total_revenue_collected'] ?? 0);
     $establishmentCount = $context['establishment_count'];
-    $recoveryColor = $collectionRate >= 70 ? 'success' : ($collectionRate >= 50 ? 'warning' : 'danger');
 @endphp
 
 <x-group-hero
@@ -45,11 +44,11 @@
     <x-slot:kpis>
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Étudiants inscrits</span>
-            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full($totalStudents) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($totalStudents) }}</span>
             <span class="gp-hero-kpi-meta">{{ $establishmentCount }} {{ \Illuminate\Support\Str::plural('établissement', $establishmentCount) }}</span>
         </div>
 
-        <div class="gp-hero-kpi" data-tone="{{ $recoveryColor }}">
+        <div class="gp-hero-kpi" data-tone="{{ RateHealth::tone($collectionRate) }}">
             <span class="gp-hero-kpi-label">Recouvrement</span>
             <span class="gp-hero-kpi-value">{{ number_format($collectionRate, 1, ',', ' ') }}&nbsp;%</span>
             <span class="gp-hero-kpi-meta">{{ FcfaFormatter::compact($revenueCollected) }} FCFA encaissés</span>
@@ -57,7 +56,7 @@
 
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Personnel</span>
-            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) ($k['total_staff'] ?? 0)) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer((int) ($k['total_staff'] ?? 0)) }}</span>
             <span class="gp-hero-kpi-meta">membres cross-groupe</span>
         </div>
 

--- a/resources/views/filament/group/partials/establishment-view-hero.blade.php
+++ b/resources/views/filament/group/partials/establishment-view-hero.blade.php
@@ -1,4 +1,4 @@
-@php use App\Support\FcfaFormatter; @endphp
+@php use App\Support\FcfaFormatter; use App\Support\RateHealth; @endphp
 
 @php
     /** @var \App\Models\Tenant $tenant */
@@ -6,7 +6,6 @@
     $students = (int) ($kpis['students'] ?? $kpis['inscriptions'] ?? 0);
     $staff = (int) ($kpis['staff'] ?? 0);
     $rate = (float) ($kpis['collection_rate'] ?? 0);
-    $rateColor = $rate >= 70 ? 'success' : ($rate >= 50 ? 'warning' : 'danger');
     $academicYear = $kpis['academic_year'] ?? 'N/A';
 
     $statusLabel = match ($tenant->status ?? '') {
@@ -52,20 +51,20 @@
     <x-slot:kpis>
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Étudiants inscrits</span>
-            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $students) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($students) }}</span>
             <span class="gp-hero-kpi-meta">année en cours</span>
         </div>
 
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Personnel</span>
-            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $staff) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($staff) }}</span>
             <span class="gp-hero-kpi-meta">membres actifs</span>
         </div>
 
-        <div class="gp-hero-kpi" data-tone="{{ $rateColor }}">
+        <div class="gp-hero-kpi" data-tone="{{ RateHealth::tone($rate) }}">
             <span class="gp-hero-kpi-label">Recouvrement</span>
             <span class="gp-hero-kpi-value">{{ number_format($rate, 1, ',', ' ') }}&nbsp;%</span>
-            <span class="gp-hero-kpi-meta">{{ $rate >= 70 ? 'sain' : ($rate >= 50 ? 'à surveiller' : 'critique') }}</span>
+            <span class="gp-hero-kpi-meta">{{ RateHealth::label($rate) }}</span>
         </div>
 
         <div class="gp-hero-kpi">

--- a/resources/views/filament/group/partials/establishments-hero.blade.php
+++ b/resources/views/filament/group/partials/establishments-hero.blade.php
@@ -1,9 +1,8 @@
-@php use App\Support\FcfaFormatter; @endphp
+@php use App\Support\FcfaFormatter; use App\Support\RateHealth; @endphp
 
 @php
     /** @var array{total_students:int,total_staff:int,establishment_count:int,avg_rate:float} $context */
     $rate = (float) $context['avg_rate'];
-    $rateColor = $rate >= 70 ? 'success' : ($rate >= 50 ? 'warning' : 'danger');
 @endphp
 
 <x-group-hero
@@ -18,13 +17,13 @@
     <x-slot:kpis>
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Étudiants inscrits</span>
-            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $context['total_students']) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($context['total_students']) }}</span>
             <span class="gp-hero-kpi-meta">cumul cross-groupe</span>
         </div>
 
         <div class="gp-hero-kpi">
             <span class="gp-hero-kpi-label">Personnel</span>
-            <span class="gp-hero-kpi-value">{{ FcfaFormatter::full((float) $context['total_staff']) }}</span>
+            <span class="gp-hero-kpi-value">{{ FcfaFormatter::integer($context['total_staff']) }}</span>
             <span class="gp-hero-kpi-meta">membres actifs</span>
         </div>
 
@@ -34,10 +33,10 @@
             <span class="gp-hero-kpi-meta">sous pilotage</span>
         </div>
 
-        <div class="gp-hero-kpi" data-tone="{{ $rateColor }}">
+        <div class="gp-hero-kpi" data-tone="{{ RateHealth::tone($rate) }}">
             <span class="gp-hero-kpi-label">Recouvrement moyen</span>
             <span class="gp-hero-kpi-value">{{ number_format($rate, 1, ',', ' ') }}&nbsp;%</span>
-            <span class="gp-hero-kpi-meta">{{ $rate >= 70 ? 'sain' : ($rate >= 50 ? 'à surveiller' : 'critique') }}</span>
+            <span class="gp-hero-kpi-meta">{{ RateHealth::label($rate) }}</span>
         </div>
     </x-slot:kpis>
 </x-group-hero>

--- a/tests/Feature/Group/FinancialAndBenchmarkingHeroTest.php
+++ b/tests/Feature/Group/FinancialAndBenchmarkingHeroTest.php
@@ -28,14 +28,13 @@ it('benchmarking view source uses FcfaFormatter and x-group-hero', function () {
     expect($source)->toContain('FcfaFormatter::millions');
 });
 
-it('financial-overview hero KPI has tone logic for collection rate', function () {
+it('financial-overview hero KPI uses RateHealth helper for tone mapping', function () {
     $source = file_get_contents(
         resource_path('views/filament/group/pages/financial-overview.blade.php')
     );
 
-    // The view must define a rate→tone mapping
-    expect($source)->toMatch('/\$rate\s*>=\s*70/');
-    expect($source)->toMatch('/\$rate\s*>=\s*50/');
+    expect($source)->toContain('RateHealth::tone($rate)');
+    expect($source)->toContain('RateHealth::label($rate)');
 });
 
 it('benchmarking hero aggregates counts from establishments array', function () {


### PR DESCRIPTION
3 agents findings :
- **RateHealth helper** — `tone()`/`label()` centralisent rate→success/warning/danger + sain/à surveiller/critique (5 duplications killed, Benchmarking gagne aussi le label)
- **HasCustomHero trait** — getHeading/getSubheading factorisés sur les 5 Page classes
- **FcfaFormatter::integer()** pour counts int (5 call sites)
- **Cache::remember 60s** sur buildTenantKpis error path (évite re-hit DB morte par poll)

139 tests passing.