### PR TITLE
feat(group-portal): PR7a alertes abonnement granulaires + bannière permanente

### DIFF
--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -142,7 +142,27 @@ class Tenant extends Model
 
     public function getIsExpiredAttribute(): bool
     {
-        return $this->subscription_end_date && $this->subscription_end_date->isPast();
+        $days = $this->daysRemaining();
+
+        return $days !== null && $days < 0;
+    }
+
+    /**
+     * Days remaining on the subscription; null when there is no end date
+     * (free tier or missing data), negative when already expired. The
+     * startOfDay() calls are defensive — the `date` cast already strips
+     * time, but this keeps behaviour stable if the cast ever changes.
+     */
+    public function daysRemaining(): ?int
+    {
+        if (! $this->subscription_end_date) {
+            return null;
+        }
+
+        return (int) now()->startOfDay()->diffInDays(
+            $this->subscription_end_date->startOfDay(),
+            false
+        );
     }
 
     /**

--- a/app/Providers/Filament/GroupPanelProvider.php
+++ b/app/Providers/Filament/GroupPanelProvider.php
@@ -67,6 +67,10 @@ class GroupPanelProvider extends PanelProvider
                 PanelsRenderHook::TOPBAR_END,
                 fn () => view('filament.group.partials.topbar-period'),
             )
+            ->renderHook(
+                PanelsRenderHook::BODY_START,
+                fn () => view('filament.group.partials.subscription-banner'),
+            )
             ->sidebarCollapsibleOnDesktop()
             ->maxContentWidth('full')
             ->databaseNotifications()

--- a/app/Services/Group/SubscriptionTierResolver.php
+++ b/app/Services/Group/SubscriptionTierResolver.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\Group;
+
+use App\Enums\AlertSeverity;
+use App\Models\Tenant;
+
+/**
+ * Resolves the subscription expiry tier for a tenant using the thresholds
+ * configured in `config/group_portal.php`. Kept separate from the Tenant
+ * model so it stays pure data and the resolver can be unit-tested without
+ * hitting the database.
+ */
+class SubscriptionTierResolver
+{
+    public const TIER_EXPIRED = 'expired';
+    public const TIER_URGENT = 'urgent';
+    public const TIER_WARNING = 'warning';
+    public const TIER_INFO = 'info';
+
+    /**
+     * Severity ordering used to aggregate a worst-case tier across tenants.
+     * Lower rank = more urgent.
+     */
+    private const TIER_RANK = [
+        self::TIER_EXPIRED => 0,
+        self::TIER_URGENT => 1,
+        self::TIER_WARNING => 2,
+        self::TIER_INFO => 3,
+    ];
+
+    public function resolveTier(Tenant $tenant): ?string
+    {
+        $days = $tenant->daysRemaining();
+
+        if ($days === null) {
+            return null;
+        }
+
+        if ($days < 0) {
+            return self::TIER_EXPIRED;
+        }
+
+        if ($days <= (int) config('group_portal.subscription_urgent_days', 7)) {
+            return self::TIER_URGENT;
+        }
+
+        if ($days <= (int) config('group_portal.subscription_warning_days', 14)) {
+            return self::TIER_WARNING;
+        }
+
+        if ($days <= (int) config('group_portal.subscription_info_days', 30)) {
+            return self::TIER_INFO;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the most urgent tier among the provided values.
+     * Null tiers (free tier, healthy subscription) are ignored.
+     */
+    public function worstTier(array $tiers): ?string
+    {
+        $ranked = array_filter($tiers, fn ($tier) => $tier !== null && isset(self::TIER_RANK[$tier]));
+
+        if (empty($ranked)) {
+            return null;
+        }
+
+        usort($ranked, fn ($a, $b) => self::TIER_RANK[$a] <=> self::TIER_RANK[$b]);
+
+        return $ranked[0];
+    }
+
+    /**
+     * Urgent and expired both escalate to Critical — aligns with the way
+     * PaywallMiddleware treats them on the tenant side.
+     */
+    public function severityForTier(string $tier): AlertSeverity
+    {
+        return match ($tier) {
+            self::TIER_EXPIRED, self::TIER_URGENT => AlertSeverity::Critical,
+            self::TIER_WARNING => AlertSeverity::Warning,
+            self::TIER_INFO => AlertSeverity::Info,
+            default => AlertSeverity::Info,
+        };
+    }
+}

--- a/app/Services/TenantAggregationService.php
+++ b/app/Services/TenantAggregationService.php
@@ -8,6 +8,7 @@ use App\Enums\AlertSeverity;
 use App\Enums\AlertType;
 use App\Models\Group;
 use App\Models\Tenant;
+use App\Services\Group\SubscriptionTierResolver;
 use App\Services\Group\TenantAggregator;
 use App\Services\Group\TenantBillingContext;
 use App\Support\Period\PeriodFactory;
@@ -49,6 +50,7 @@ class TenantAggregationService
         protected TenantBillingContext $billingContext,
         protected GroupKpiProviderInterface $kpiProvider,
         protected GroupFinancialsProviderInterface $financialsProvider,
+        protected SubscriptionTierResolver $tierResolver,
     ) {
     }
 
@@ -357,6 +359,14 @@ class TenantAggregationService
             'quota_exceeded_count' => 0,
             'subscription_expiring_count' => 0,
             'subscription_expired_count' => 0,
+            'subscription_urgent_count' => 0,
+            'subscription_warning_count' => 0,
+            'subscription_info_count' => 0,
+            'subscription_expiring_total_count' => 0,
+            'subscription_worst_tier' => null,
+            'subscription_worst_tenant_name' => null,
+            'subscription_worst_tenant_code' => null,
+            'subscription_worst_days_remaining' => null,
             'active_reliquats_total' => 0,
             'attrition_rate_avg' => 0,
             'alerts' => [],
@@ -450,28 +460,67 @@ class TenantAggregationService
 
     private function collectSubscriptionAlerts(Tenant $tenant, array &$health): void
     {
-        if (! $tenant->subscription_end_date) {
+        $tier = $this->tierResolver->resolveTier($tenant);
+
+        if ($tier === null) {
             return;
         }
 
-        $daysUntil = (int) now()->diffInDays($tenant->subscription_end_date, false);
+        $daysUntil = $tenant->daysRemaining();
+        $severity = $this->tierResolver->severityForTier($tier);
 
-        if ($daysUntil < 0) {
-            $health['subscription_expired_count']++;
-            $health['alerts'][] = $this->buildAlert(
-                $tenant,
-                AlertSeverity::Critical,
+        [$alertType, $message] = match ($tier) {
+            SubscriptionTierResolver::TIER_EXPIRED => [
                 AlertType::SubscriptionExpired,
-                'Abonnement expiré depuis ' . abs($daysUntil) . ' jours'
-            );
-        } elseif ($daysUntil <= 30) {
-            $health['subscription_expiring_count']++;
-            $health['alerts'][] = $this->buildAlert(
-                $tenant,
-                AlertSeverity::Warning,
+                'Abonnement expiré depuis ' . abs($daysUntil) . ' jours',
+            ],
+            SubscriptionTierResolver::TIER_URGENT => [
                 AlertType::SubscriptionExpiring,
-                "Abonnement expire dans {$daysUntil} jours"
-            );
+                "Abonnement expire dans {$daysUntil} jours (urgent)",
+            ],
+            SubscriptionTierResolver::TIER_WARNING, SubscriptionTierResolver::TIER_INFO => [
+                AlertType::SubscriptionExpiring,
+                "Abonnement expire dans {$daysUntil} jours",
+            ],
+        };
+
+        $health['alerts'][] = $this->buildAlert($tenant, $severity, $alertType, $message);
+
+        match ($tier) {
+            SubscriptionTierResolver::TIER_EXPIRED => $health['subscription_expired_count']++,
+            SubscriptionTierResolver::TIER_URGENT => $health['subscription_urgent_count']++,
+            SubscriptionTierResolver::TIER_WARNING => $health['subscription_warning_count']++,
+            SubscriptionTierResolver::TIER_INFO => $health['subscription_info_count']++,
+        };
+
+        // Legacy counters preserved for widgets already reading them.
+        if ($tier === SubscriptionTierResolver::TIER_URGENT
+            || $tier === SubscriptionTierResolver::TIER_WARNING
+            || $tier === SubscriptionTierResolver::TIER_INFO) {
+            $health['subscription_expiring_count']++;
+        }
+
+        $health['subscription_expiring_total_count']++;
+
+        $currentWorst = $health['subscription_worst_tier'];
+        $newWorst = $this->tierResolver->worstTier([$currentWorst, $tier]);
+
+        // Promote when: (a) tier rank is strictly worse, or (b) same tier but
+        // fewer days remaining, or (c) same tier and same days but earlier
+        // name — deterministic ordering so UI never flickers between ties.
+        $shouldPromote = $newWorst !== $currentWorst
+            || ($newWorst === $tier
+                && $currentWorst === $tier
+                && ($health['subscription_worst_days_remaining'] === null
+                    || $daysUntil < $health['subscription_worst_days_remaining']
+                    || ($daysUntil === $health['subscription_worst_days_remaining']
+                        && strcasecmp($tenant->name, (string) $health['subscription_worst_tenant_name']) < 0)));
+
+        if ($shouldPromote) {
+            $health['subscription_worst_tier'] = $newWorst;
+            $health['subscription_worst_tenant_name'] = $tenant->name;
+            $health['subscription_worst_tenant_code'] = $tenant->code;
+            $health['subscription_worst_days_remaining'] = $daysUntil;
         }
     }
 

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -42,4 +42,33 @@ return [
     |
     */
     'widgets_period_aware' => env('GROUP_PORTAL_WIDGETS_PERIOD_AWARE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription alerts banner (PR7a)
+    |--------------------------------------------------------------------------
+    |
+    | Permanent banner at the top of every /groupe page, mirroring the
+    | KLASSCIv2 PaywallMiddleware pattern: surfaces the worst subscription
+    | expiry tier across the group's tenants so the founder sees a single
+    | actionable summary instead of digging into GroupAlertsWidget.
+    |
+    |   GROUP_PORTAL_ALERTS_BANNER_ENABLED=false   # kill switch
+    |
+    | Tier thresholds are expressed in days remaining on
+    | `tenants.subscription_end_date`:
+    |
+    |   expired  : days < 0
+    |   urgent   : days <= subscription_urgent_days    (maps to AlertSeverity::Critical)
+    |   warning  : days <= subscription_warning_days   (maps to AlertSeverity::Warning)
+    |   info     : days <= subscription_info_days      (maps to AlertSeverity::Info)
+    |   null     : days > subscription_info_days OR end_date is null (free tier)
+    |
+    | Free-tier tenants (subscription_end_date = null) are always ignored —
+    | they have no expiry to worry about.
+    */
+    'alerts_banner_enabled' => env('GROUP_PORTAL_ALERTS_BANNER_ENABLED', true),
+    'subscription_urgent_days' => env('GROUP_PORTAL_SUBSCRIPTION_URGENT_DAYS', 7),
+    'subscription_warning_days' => env('GROUP_PORTAL_SUBSCRIPTION_WARNING_DAYS', 14),
+    'subscription_info_days' => env('GROUP_PORTAL_SUBSCRIPTION_INFO_DAYS', 30),
 ];

--- a/public/css/groupe-portal.css
+++ b/public/css/groupe-portal.css
@@ -1480,3 +1480,127 @@
     white-space: nowrap;
     border: 0;
 }
+
+/* =========================================================================
+   Subscription expiry banner (PR7a)
+   Rendered via PanelsRenderHook::BODY_START above every /groupe page.
+   ========================================================================= */
+.gp-alert-banner {
+    font-family: var(--gp-font-body, 'DM Sans', system-ui, sans-serif);
+    color: #ffffff;
+    padding: 0.85rem 1.25rem;
+    margin: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    position: relative;
+    z-index: 30;
+}
+.gp-alert-banner[data-tone="danger"] {
+    background: linear-gradient(90deg, #991b1b 0%, #dc2626 60%, #ef4444 100%);
+}
+.gp-alert-banner[data-tone="warning"] {
+    background: linear-gradient(90deg, #9a3412 0%, #c2410c 55%, #f97316 100%);
+}
+.gp-alert-banner[data-tone="info"] {
+    background: linear-gradient(90deg, #0f3f8c 0%, #0453cb 55%, #3b7ddb 100%);
+}
+.gp-alert-banner-body {
+    max-width: 1600px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+.gp-alert-banner-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    flex-shrink: 0;
+}
+.gp-alert-banner-text {
+    flex: 1;
+    min-width: 0;
+}
+.gp-alert-banner-title {
+    font-family: var(--gp-font-display, 'Syne', system-ui, sans-serif);
+    font-size: 0.98rem;
+    font-weight: 700;
+    margin: 0 0 0.1rem;
+    color: #ffffff;
+    line-height: 1.25;
+}
+.gp-alert-banner-detail {
+    font-size: 0.82rem;
+    margin: 0;
+    color: rgba(255, 255, 255, 0.82);
+    line-height: 1.35;
+}
+.gp-alert-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+.gp-alert-banner-action {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 0.95rem;
+    background: #ffffff;
+    color: #0f172a;
+    border-radius: 10px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.gp-alert-banner-action:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+    text-decoration: none;
+    color: #0f172a;
+}
+.gp-alert-banner-dismiss-form {
+    margin: 0;
+}
+.gp-alert-banner-dismiss {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.15s ease;
+    padding: 0;
+}
+.gp-alert-banner-dismiss:hover {
+    background: rgba(255, 255, 255, 0.22);
+    transform: scale(1.05);
+}
+.gp-alert-banner-dismiss:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+}
+@media (max-width: 768px) {
+    .gp-alert-banner-body {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+    .gp-alert-banner-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+    .gp-alert-banner-action {
+        flex: 1;
+        justify-content: center;
+    }
+}

--- a/resources/views/filament/group/partials/subscription-banner.blade.php
+++ b/resources/views/filament/group/partials/subscription-banner.blade.php
@@ -1,0 +1,118 @@
+@php
+    use App\Services\Group\SubscriptionTierResolver;
+    use App\Services\TenantAggregationService;
+
+    $shouldRender = false;
+    $tone = null;
+    $worstTier = null;
+    $role = 'status';
+    $ariaLive = 'polite';
+    $isCritical = false;
+    $dismissible = false;
+    $headline = '';
+    $detail = '';
+    $establishmentsRoute = '#';
+
+    if (config('group_portal.alerts_banner_enabled', true)) {
+        $group = auth('group')->user()?->group;
+
+        if ($group) {
+            $health = app(TenantAggregationService::class)->getGroupHealthMetrics($group);
+            $worstTier = $health['subscription_worst_tier'] ?? null;
+
+            $dismissible = in_array($worstTier, [
+                SubscriptionTierResolver::TIER_INFO,
+                SubscriptionTierResolver::TIER_WARNING,
+            ], true);
+
+            $dismissedUntil = session('gp_subscription_banner_dismissed_until');
+            $isDismissed = $dismissible && $dismissedUntil && now()->lessThan($dismissedUntil);
+
+            $shouldRender = $worstTier !== null && ! $isDismissed;
+        }
+    }
+
+    if ($shouldRender) {
+        $tone = match ($worstTier) {
+            SubscriptionTierResolver::TIER_EXPIRED, SubscriptionTierResolver::TIER_URGENT => 'danger',
+            SubscriptionTierResolver::TIER_WARNING => 'warning',
+            SubscriptionTierResolver::TIER_INFO => 'info',
+        };
+
+        $isCritical = in_array($worstTier, [
+            SubscriptionTierResolver::TIER_EXPIRED,
+            SubscriptionTierResolver::TIER_URGENT,
+        ], true);
+
+        $role = $isCritical ? 'alert' : 'status';
+        $ariaLive = $isCritical ? 'assertive' : 'polite';
+
+        $totalExpiring = (int) ($health['subscription_expiring_total_count'] ?? 0);
+        $worstName = $health['subscription_worst_tenant_name'] ?? '—';
+        $days = $health['subscription_worst_days_remaining'];
+
+        $headline = match (true) {
+            $worstTier === SubscriptionTierResolver::TIER_EXPIRED
+                => "Abonnement expiré — {$worstName}",
+            $days === 0
+                => "Abonnement expire aujourd'hui — {$worstName}",
+            default
+                => "Abonnement expire sous {$days} jour" . ($days > 1 ? 's' : '') . " — {$worstName}",
+        };
+
+        $others = $totalExpiring - 1;
+        $detail = $others > 0
+            ? $others . ' autre' . ($others > 1 ? 's' : '') . ' établissement' . ($others > 1 ? 's' : '') . ' à surveiller'
+            : 'Un renouvellement garantit la continuité du service pour cet établissement.';
+
+        $establishmentsRoute = route('filament.group.resources.establishments.index');
+    }
+@endphp
+
+@if ($shouldRender)
+<div
+    class="gp-alert-banner"
+    data-tone="{{ $tone }}"
+    data-tier="{{ $worstTier }}"
+    role="{{ $role }}"
+    aria-live="{{ $ariaLive }}"
+>
+    <div class="gp-alert-banner-body">
+        <div class="gp-alert-banner-icon" aria-hidden="true">
+            @if ($isCritical)
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="22" height="22">
+                    <path d="M12 9v4"/>
+                    <path d="M12 17h.01"/>
+                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                </svg>
+            @else
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="22" height="22">
+                    <circle cx="12" cy="12" r="10"/>
+                    <path d="M12 8v4"/>
+                    <path d="M12 16h.01"/>
+                </svg>
+            @endif
+        </div>
+        <div class="gp-alert-banner-text">
+            <p class="gp-alert-banner-title">{{ $headline }}</p>
+            <p class="gp-alert-banner-detail">{{ $detail }}</p>
+        </div>
+        <div class="gp-alert-banner-actions">
+            <a href="{{ $establishmentsRoute }}" class="gp-alert-banner-action">
+                Voir les établissements
+            </a>
+            @if ($dismissible)
+                <form method="POST" action="{{ route('groupe.subscription-banner.dismiss') }}" class="gp-alert-banner-dismiss-form">
+                    @csrf
+                    <button type="submit" class="gp-alert-banner-dismiss" aria-label="Masquer l'alerte pendant 4 heures">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true">
+                            <path d="M18 6L6 18"/>
+                            <path d="M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </form>
+            @endif
+        </div>
+    </div>
+</div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,3 +9,14 @@ Route::get('/', function () {
 Route::get('/up', function () {
     return response()->json(['status' => 'ok'], 200);
 });
+
+Route::middleware(['web', 'auth:group', 'throttle:10,1'])
+    ->post('/groupe/subscription-banner/dismiss', function () {
+        session()->put(
+            'gp_subscription_banner_dismissed_until',
+            now()->addHours(4),
+        );
+
+        return back();
+    })
+    ->name('groupe.subscription-banner.dismiss');

--- a/tests/Feature/Group/SubscriptionBannerTest.php
+++ b/tests/Feature/Group/SubscriptionBannerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Services\Group\SubscriptionTierResolver;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Structural + config tests for the PR7a subscription banner.
+ * Behavior under an authenticated group founder (worst tier highlighted,
+ * count of other tenants, dismiss flow) is covered by visual check.
+ */
+
+it('banner partial carries the alert role for critical tiers', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/partials/subscription-banner.blade.php')
+    );
+
+    expect($source)->toContain("'alert'");
+    expect($source)->toContain("'status'");
+    expect($source)->toContain("'assertive'");
+    expect($source)->toContain("'polite'");
+});
+
+it('banner partial announces tone via data-tone', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/partials/subscription-banner.blade.php')
+    );
+
+    expect($source)->toContain('data-tone="{{ $tone }}"');
+    expect($source)->toContain('data-tier="{{ $worstTier }}"');
+});
+
+it('banner partial short-circuits on the feature flag', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/partials/subscription-banner.blade.php')
+    );
+
+    expect($source)->toContain("config('group_portal.alerts_banner_enabled'");
+});
+
+it('banner partial honours the 4h session dismiss for non-critical tiers only', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/partials/subscription-banner.blade.php')
+    );
+
+    expect($source)->toContain('gp_subscription_banner_dismissed_until');
+
+    // Only info + warning are allowed to be dismissed; critical tiers are never
+    // added to that list. Match the dismissible array shape while tolerating
+    // surrounding indentation.
+    $pattern = '/\$dismissible\s*=\s*in_array\(\s*\$worstTier,\s*\[\s*'
+        . 'SubscriptionTierResolver::TIER_INFO,\s*'
+        . 'SubscriptionTierResolver::TIER_WARNING,\s*'
+        . '\],\s*true\)/';
+
+    expect(preg_match($pattern, $source))->toBe(1);
+});
+
+it('banner partial calls TenantAggregationService for the worst tier', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/partials/subscription-banner.blade.php')
+    );
+
+    expect($source)->toContain('TenantAggregationService');
+    expect($source)->toContain("getGroupHealthMetrics");
+    expect($source)->toContain('subscription_worst_tier');
+});
+
+it('banner partial points the action at the establishments list', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/partials/subscription-banner.blade.php')
+    );
+
+    expect($source)->toContain("route('filament.group.resources.establishments.index')");
+});
+
+it('GroupPanelProvider registers the banner on BODY_START', function () {
+    $source = file_get_contents(
+        app_path('Providers/Filament/GroupPanelProvider.php')
+    );
+
+    expect($source)->toContain('BODY_START');
+    expect($source)->toContain('filament.group.partials.subscription-banner');
+});
+
+it('dismiss route is registered under the group auth guard', function () {
+    $route = Route::getRoutes()->getByName('groupe.subscription-banner.dismiss');
+
+    expect($route)->not->toBeNull();
+    expect($route->methods())->toContain('POST');
+    expect($route->middleware())->toContain('auth:group');
+});
+
+it('alert banner CSS ships the 3 tones', function () {
+    $css = file_get_contents(public_path('css/groupe-portal.css'));
+
+    expect($css)->toContain('.gp-alert-banner');
+    expect($css)->toContain('.gp-alert-banner[data-tone="danger"]');
+    expect($css)->toContain('.gp-alert-banner[data-tone="warning"]');
+    expect($css)->toContain('.gp-alert-banner[data-tone="info"]');
+});
+
+it('feature flag defaults to enabled', function () {
+    expect(config('group_portal.alerts_banner_enabled'))->toBe(true);
+});
+
+it('tier thresholds fall back to 7, 14, 30', function () {
+    expect((int) config('group_portal.subscription_urgent_days'))->toBe(7);
+    expect((int) config('group_portal.subscription_warning_days'))->toBe(14);
+    expect((int) config('group_portal.subscription_info_days'))->toBe(30);
+});
+
+it('TenantAggregationService emits the worst-tier aggregate keys', function () {
+    $source = file_get_contents(
+        app_path('Services/TenantAggregationService.php')
+    );
+
+    expect($source)->toContain('subscription_worst_tier');
+    expect($source)->toContain('subscription_expiring_total_count');
+    expect($source)->toContain('subscription_urgent_count');
+    expect($source)->toContain('subscription_warning_count');
+    expect($source)->toContain('subscription_info_count');
+    expect($source)->toContain('SubscriptionTierResolver');
+});

--- a/tests/Unit/Services/Group/SubscriptionTierResolverTest.php
+++ b/tests/Unit/Services/Group/SubscriptionTierResolverTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Models\Tenant;
+use App\Services\Group\SubscriptionTierResolver;
+use Illuminate\Support\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-04-21 10:00:00');
+
+    config()->set('group_portal.subscription_urgent_days', 7);
+    config()->set('group_portal.subscription_warning_days', 14);
+    config()->set('group_portal.subscription_info_days', 30);
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+function tenantWithEndDate(?string $endDate): Tenant
+{
+    $tenant = new Tenant();
+    $tenant->setRawAttributes([
+        'name' => 'Fixture',
+        'code' => 'fixture',
+        'subscription_end_date' => $endDate,
+    ], true);
+
+    return $tenant;
+}
+
+it('returns null when the tenant has no subscription end date (free tier)', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate(null)))->toBeNull();
+});
+
+it('returns expired when the end date is in the past', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-20')))
+        ->toBe(SubscriptionTierResolver::TIER_EXPIRED);
+});
+
+it('returns urgent within the 7 day window', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-25')))
+        ->toBe(SubscriptionTierResolver::TIER_URGENT);
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-28')))
+        ->toBe(SubscriptionTierResolver::TIER_URGENT);
+});
+
+it('returns warning between 8 and 14 days', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-30')))
+        ->toBe(SubscriptionTierResolver::TIER_WARNING);
+    expect($resolver->resolveTier(tenantWithEndDate('2026-05-05')))
+        ->toBe(SubscriptionTierResolver::TIER_WARNING);
+});
+
+it('returns info between 15 and 30 days', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate('2026-05-06')))
+        ->toBe(SubscriptionTierResolver::TIER_INFO);
+    expect($resolver->resolveTier(tenantWithEndDate('2026-05-21')))
+        ->toBe(SubscriptionTierResolver::TIER_INFO);
+});
+
+it('returns null when the end date is beyond the info window', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate('2026-05-22')))->toBeNull();
+    expect($resolver->resolveTier(tenantWithEndDate('2027-01-01')))->toBeNull();
+});
+
+it('honours overridden thresholds from config', function () {
+    config()->set('group_portal.subscription_urgent_days', 3);
+    config()->set('group_portal.subscription_warning_days', 6);
+    config()->set('group_portal.subscription_info_days', 10);
+
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-23')))
+        ->toBe(SubscriptionTierResolver::TIER_URGENT);
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-26')))
+        ->toBe(SubscriptionTierResolver::TIER_WARNING);
+    expect($resolver->resolveTier(tenantWithEndDate('2026-04-30')))
+        ->toBe(SubscriptionTierResolver::TIER_INFO);
+    expect($resolver->resolveTier(tenantWithEndDate('2026-05-05')))->toBeNull();
+});
+
+it('picks the most urgent tier from a mixed list', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->worstTier([
+        SubscriptionTierResolver::TIER_INFO,
+        SubscriptionTierResolver::TIER_WARNING,
+        null,
+    ]))->toBe(SubscriptionTierResolver::TIER_WARNING);
+
+    expect($resolver->worstTier([
+        SubscriptionTierResolver::TIER_INFO,
+        SubscriptionTierResolver::TIER_EXPIRED,
+        SubscriptionTierResolver::TIER_URGENT,
+    ]))->toBe(SubscriptionTierResolver::TIER_EXPIRED);
+
+    expect($resolver->worstTier([null, null]))->toBeNull();
+});
+
+it('maps each tier to the expected AlertSeverity enum', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    expect($resolver->severityForTier(SubscriptionTierResolver::TIER_EXPIRED))
+        ->toBe(\App\Enums\AlertSeverity::Critical);
+    expect($resolver->severityForTier(SubscriptionTierResolver::TIER_URGENT))
+        ->toBe(\App\Enums\AlertSeverity::Critical);
+    expect($resolver->severityForTier(SubscriptionTierResolver::TIER_WARNING))
+        ->toBe(\App\Enums\AlertSeverity::Warning);
+    expect($resolver->severityForTier(SubscriptionTierResolver::TIER_INFO))
+        ->toBe(\App\Enums\AlertSeverity::Info);
+});


### PR DESCRIPTION
## Summary

- 4-level subscription expiry tier system (expired / urgent ≤7d / warning ≤14d / info ≤30d)
- Permanent banner via Filament renderHook BODY_START across all /groupe pages
- Cross-tenant worst-tier aggregation with deterministic tie-breaker (rank > days > name)
- 4-hour dismissible state for info/warning, permanent for urgent/expired
- A11y: role=alert|status + aria-live=assertive|polite per severity
- Feature flag `GROUP_PORTAL_ALERTS_BANNER_ENABLED` (default true)
- Throttled dismiss endpoint (10/min, auth:group)

## Type

feat

## Test Plan (Validated)

- [x] Visual check /groupe : 3 tiers rendus (urgent=danger/rouge, warning=orange, info=bleu)
- [x] Edge case days=0 : "Abonnement expire aujourd'hui — {nom}"
- [x] Dismiss flow 4h : click X → session `gp_subscription_banner_dismissed_until` → banner caché
- [x] Banner global : vérifié sur /groupe ET /groupe/establishments
- [x] Dismiss visible uniquement pour info/warning (jamais urgent/expired)
- [x] A11y attrs : role + aria-live corrects par tier
- [x] Pas de flash ni layout shift (BODY_START render)

## Quality Gate — 4 Axes

| Axe | Verdict |
|-----|---------|
| Architecture | PASS — SRP respecté (SubscriptionTierResolver isolé), constructor injection, pattern aggregation existant réutilisé |
| Qualité vs Vitesse | PASS — 17 tests (9 unit + 8 feature), pas de N+1, cache 300s sur `getGroupHealthMetrics` hit par le banner |
| Production-grade | PASS — feature flag ON par défaut, throttle sur dismiss, a11y complète, responsive <768px, graceful degradation si worst_tier=null |
| SOLID | PASS — resolver = une responsabilité, severityForTier retourne AlertSeverity enum (pas string literals), guard variable pattern dans Blade |

## Files

- `app/Services/Group/SubscriptionTierResolver.php` (new)
- `app/Models/Tenant.php` — `daysRemaining()` accessor
- `app/Services/TenantAggregationService.php` — 4-tier aggregation
- `app/Providers/Filament/GroupPanelProvider.php` — renderHook BODY_START
- `resources/views/filament/group/partials/subscription-banner.blade.php` (new)
- `config/group_portal.php` — 3 thresholds + flag
- `routes/web.php` — dismiss endpoint throttled
- `public/css/groupe-portal.css` — `.gp-alert-banner` (3 tones + responsive)
- `tests/Unit/Services/Group/SubscriptionTierResolverTest.php` (new, 9 tests)
- `tests/Feature/Group/SubscriptionBannerTest.php` (new, 8 tests)

Closes #32