### PR TITLE
fix(group-portal): show create/edit actions on ViewGroup relation managers

### DIFF
--- a/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
@@ -16,6 +16,11 @@ class MembersRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'name';
 
+    public function isReadOnly(): bool
+    {
+        return false;
+    }
+
     public function form(Form $form): Form
     {
         return $form

--- a/app/Filament/Resources/GroupResource/RelationManagers/TenantsRelationManager.php
+++ b/app/Filament/Resources/GroupResource/RelationManagers/TenantsRelationManager.php
@@ -16,6 +16,11 @@ class TenantsRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'name';
 
+    public function isReadOnly(): bool
+    {
+        return false;
+    }
+
     public function table(Table $table): Table
     {
         return $table


### PR DESCRIPTION
## Summary

- Override \`isReadOnly()\` on \`MembersRelationManager\` and \`TenantsRelationManager\` to return false
- Fixes missing \"Ajouter un membre\" and \"Ajouter un établissement\" buttons on ViewGroup page (\`/admin/groups/{id}\`)

## Context

Filament v3 hides RelationManager create/edit/delete actions on ViewPage by default. The \`CreateAction::make()\` definitions were already correct but invisible because the page is read-only. Overriding \`isReadOnly()\` is the idiomatic Filament v3 fix.

## Type

fix

## Test Plan

- [ ] Go to /admin/groups/{id} (ViewGroup page, no /edit)
- [ ] Click \"Membres du groupe\" tab — \"Ajouter un membre\" button should appear top right
- [ ] Click \"Établissements du groupe\" tab — \"Attacher\" action should appear
- [ ] Verify create/edit/delete actions still work on /admin/groups/{id}/edit (should be unchanged)