### PR TITLE
feat(group-portal): PR7b 4 alertes supplémentaires (plan/stale/SSL/enrollment)

### DIFF
--- a/app/Enums/AlertType.php
+++ b/app/Enums/AlertType.php
@@ -10,4 +10,8 @@ enum AlertType: string
     case SubscriptionExpiring = 'subscription_expiring';
     case HighAttrition = 'high_attrition';
     case ActiveReliquats = 'active_reliquats';
+    case PlanMismatch = 'plan_mismatch';
+    case StaleTenant = 'stale_tenant';
+    case SslExpiring = 'ssl_expiring';
+    case EnrollmentDecline = 'enrollment_decline';
 }

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -79,6 +79,30 @@ class Tenant extends Model
         return $this->hasMany(TenantHealthCheck::class);
     }
 
+    /**
+     * Latest health check across all check types — used by the group portal
+     * stale-tenant detection (tenant hasn't checked in recently OR is flagged
+     * unhealthy). latestOfMany() avoids the per-tenant subquery that naive
+     * "$tenant->healthChecks->first()" would trigger on a group dashboard.
+     */
+    public function latestHealthCheck()
+    {
+        return $this->hasOne(TenantHealthCheck::class)->latestOfMany('checked_at');
+    }
+
+    /**
+     * Latest ssl_certificate health check specifically. Filtered aggregate so
+     * PR7b SSL expiry alerts can read `metadata.days_remaining` directly
+     * without scanning the full health_checks history.
+     */
+    public function latestSslHealthCheck()
+    {
+        return $this->hasOne(TenantHealthCheck::class)->ofMany(
+            ['checked_at' => 'max'],
+            fn ($query) => $query->where('check_type', 'ssl_certificate')
+        );
+    }
+
     public function backups()
     {
         return $this->hasMany(TenantBackup::class);

--- a/app/Services/Group/EnrollmentTrendAnalyzer.php
+++ b/app/Services/Group/EnrollmentTrendAnalyzer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services\Group;
+
+/**
+ * Detects a sustained enrollment decline over two consecutive months.
+ *
+ * The requirement "two consecutive months" is a noise filter — a single-month
+ * drop is frequently seasonal (holidays, exam weeks, transfer cycles). Only
+ * flags tenants where BOTH the current-vs-previous AND the previous-vs-before
+ * comparisons exceed the configured percentage threshold.
+ *
+ * Pure: takes monthly counts, returns a verdict. Production code feeds it the
+ * result of a `SELECT MONTH(created_at), COUNT(*) ... GROUP BY MONTH` query.
+ */
+class EnrollmentTrendAnalyzer
+{
+    /**
+     * Analyses a three-month window of new-inscription counts.
+     *
+     * @param  int  $currentMonth     New inscriptions in the current calendar month.
+     * @param  int  $previousMonth    New inscriptions in the previous calendar month.
+     * @param  int  $twoMonthsAgo     New inscriptions two calendar months back.
+     *
+     * @return array{declining: bool, drop_pct_current: ?float, drop_pct_previous: ?float}|null
+     *         Null when no decline is detected. When declining, returns both
+     *         drop percentages so the caller can build a precise alert message.
+     */
+    public function detectDecline(int $currentMonth, int $previousMonth, int $twoMonthsAgo): ?array
+    {
+        if ($previousMonth === 0 || $twoMonthsAgo === 0) {
+            return null;
+        }
+
+        $dropCurrent = $this->percentageDrop($currentMonth, $previousMonth);
+        $dropPrevious = $this->percentageDrop($previousMonth, $twoMonthsAgo);
+
+        $threshold = (float) config('group_portal.enrollment_decline_threshold_pct', 10);
+
+        if ($dropCurrent < $threshold || $dropPrevious < $threshold) {
+            return null;
+        }
+
+        return [
+            'declining' => true,
+            'drop_pct_current' => round($dropCurrent, 1),
+            'drop_pct_previous' => round($dropPrevious, 1),
+        ];
+    }
+
+    /**
+     * Positive return value = actual decline (new < old). Negative values
+     * mean growth — the caller compares against the threshold, not against
+     * zero, so a 5% decline is correctly filtered out at threshold 10%.
+     */
+    private function percentageDrop(int $newCount, int $oldCount): float
+    {
+        if ($oldCount === 0) {
+            return 0.0;
+        }
+
+        return (($oldCount - $newCount) / $oldCount) * 100.0;
+    }
+}

--- a/app/Services/Group/HealthCheckAlertResolver.php
+++ b/app/Services/Group/HealthCheckAlertResolver.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Services\Group;
+
+use App\Enums\AlertSeverity;
+use App\Models\Tenant;
+use App\Models\TenantHealthCheck;
+
+/**
+ * Classifies a tenant's health-check snapshot into group-portal alert tiers.
+ * Pure: no database access, no side effects — the caller is responsible for
+ * eager-loading `latestHealthCheck` / `latestSslHealthCheck` to avoid N+1.
+ *
+ * Two independent decisions per tenant:
+ *   - SSL tier: critical / warning / null, based on metadata.days_remaining
+ *   - Staleness tier: unhealthy / stale / null, based on last_deployed_at +
+ *                     latest health check status
+ *
+ * Tiers are resolved separately so the same tenant can surface both alerts
+ * (e.g. deployed 40 days ago AND SSL expiring in 5 days).
+ */
+class HealthCheckAlertResolver
+{
+    public const SSL_TIER_CRITICAL = 'critical';
+    public const SSL_TIER_WARNING = 'warning';
+
+    public const STALE_TIER_UNHEALTHY = 'unhealthy';
+    public const STALE_TIER_STALE = 'stale';
+
+    /**
+     * Returns null when: no ssl_certificate check found, metadata missing
+     * `days_remaining`, or days_remaining > warning threshold. The last SSL
+     * check is considered authoritative — the caller should scope to the
+     * tenant's latest row (via Tenant::latestSslHealthCheck).
+     */
+    public function resolveSslTier(?TenantHealthCheck $latestSslCheck): ?string
+    {
+        if ($latestSslCheck === null) {
+            return null;
+        }
+
+        $metadata = $latestSslCheck->metadata;
+        if (! is_array($metadata) || ! array_key_exists('days_remaining', $metadata)) {
+            return null;
+        }
+
+        $days = (int) $metadata['days_remaining'];
+
+        if ($days <= (int) config('group_portal.ssl_expiry_critical_days', 7)) {
+            return self::SSL_TIER_CRITICAL;
+        }
+
+        if ($days <= (int) config('group_portal.ssl_expiry_warning_days', 15)) {
+            return self::SSL_TIER_WARNING;
+        }
+
+        return null;
+    }
+
+    /**
+     * `unhealthy` (latest overall check failed) takes precedence over
+     * `stale` (deployment age) — the two conditions can co-occur, but the
+     * UI only surfaces one alert per tenant to avoid noise. `null` when
+     * neither applies AND when `last_deployed_at` is unset (newly created
+     * tenants aren't stale).
+     */
+    public function resolveStaleTier(Tenant $tenant, ?TenantHealthCheck $latestCheck): ?string
+    {
+        if ($latestCheck !== null && $latestCheck->status === 'unhealthy') {
+            return self::STALE_TIER_UNHEALTHY;
+        }
+
+        if ($tenant->last_deployed_at === null) {
+            return null;
+        }
+
+        $threshold = (int) config('group_portal.stale_tenant_days', 30);
+        if ($tenant->last_deployed_at->diffInDays(now()) > $threshold) {
+            return self::STALE_TIER_STALE;
+        }
+
+        return null;
+    }
+
+    public function severityForSslTier(string $tier): AlertSeverity
+    {
+        return match ($tier) {
+            self::SSL_TIER_CRITICAL => AlertSeverity::Critical,
+            self::SSL_TIER_WARNING => AlertSeverity::Warning,
+            default => AlertSeverity::Info,
+        };
+    }
+
+    public function severityForStaleTier(string $tier): AlertSeverity
+    {
+        return match ($tier) {
+            self::STALE_TIER_UNHEALTHY => AlertSeverity::Critical,
+            self::STALE_TIER_STALE => AlertSeverity::Warning,
+            default => AlertSeverity::Info,
+        };
+    }
+}

--- a/app/Services/TenantAggregationService.php
+++ b/app/Services/TenantAggregationService.php
@@ -8,6 +8,8 @@ use App\Enums\AlertSeverity;
 use App\Enums\AlertType;
 use App\Models\Group;
 use App\Models\Tenant;
+use App\Services\Group\EnrollmentTrendAnalyzer;
+use App\Services\Group\HealthCheckAlertResolver;
 use App\Services\Group\SubscriptionTierResolver;
 use App\Services\Group\TenantAggregator;
 use App\Services\Group\TenantBillingContext;
@@ -51,6 +53,8 @@ class TenantAggregationService
         protected GroupKpiProviderInterface $kpiProvider,
         protected GroupFinancialsProviderInterface $financialsProvider,
         protected SubscriptionTierResolver $tierResolver,
+        protected HealthCheckAlertResolver $healthResolver,
+        protected EnrollmentTrendAnalyzer $enrollmentAnalyzer,
     ) {
     }
 
@@ -369,6 +373,12 @@ class TenantAggregationService
             'subscription_worst_days_remaining' => null,
             'active_reliquats_total' => 0,
             'attrition_rate_avg' => 0,
+            'plan_overage_count' => 0,
+            'stale_tenant_count' => 0,
+            'unhealthy_tenant_count' => 0,
+            'ssl_expiring_count' => 0,
+            'ssl_critical_count' => 0,
+            'enrollment_decline_count' => 0,
             'alerts' => [],
         ];
 
@@ -376,8 +386,40 @@ class TenantAggregationService
         // Health metrics are snapshot-style — no Period forwarded to tenants.
         $healthDetails = $this->aggregator->aggregate($group, self::class, 'computeTenantHealthDetails', 'HealthDetails');
 
+        $healthAlertsEnabled = (bool) config('group_portal.health_alerts_enabled', true);
+        $monthlyEnrollments = [];
+
+        if ($healthAlertsEnabled) {
+            // Eager-load the two latestOfMany relations once per group call to
+            // avoid one extra SELECT per tenant in the alert loop below.
+            $group->activeTenants->load(['latestHealthCheck', 'latestSslHealthCheck']);
+
+            // Fan out to tenant databases in parallel — we need 3 months of
+            // new inscriptions per tenant for the decline analyzer, and the
+            // aggregator already handles connection pooling + error isolation.
+            $monthlyEnrollments = $this->aggregator->aggregate(
+                $group,
+                self::class,
+                'computeTenantMonthlyEnrollments',
+                'MonthlyEnrollments'
+            );
+        }
+
         foreach ($group->activeTenants as $tenant) {
-            $this->collectQuotaAlerts($tenant, $health);
+            $planMismatchFired = false;
+
+            if ($healthAlertsEnabled) {
+                $planMismatchFired = $this->collectPlanMismatchAlerts($tenant, $health);
+                $this->collectStaleTenantAlerts($tenant, $health);
+                $this->collectSslExpiryAlerts($tenant, $health);
+                $this->collectEnrollmentDeclineAlerts(
+                    $tenant,
+                    $health,
+                    $monthlyEnrollments[$tenant->code] ?? null
+                );
+            }
+
+            $this->collectQuotaAlerts($tenant, $health, $planMismatchFired);
             $this->collectSubscriptionAlerts($tenant, $health);
 
             $details = $healthDetails[$tenant->code] ?? null;
@@ -435,9 +477,16 @@ class TenantAggregationService
         ];
     }
 
-    private function collectQuotaAlerts(Tenant $tenant, array &$health): void
+    /**
+     * When `$planMismatchFired` is true, PlanMismatch has already surfaced a
+     * richer students-quota alert (with the plan name + upgrade hint) — we
+     * skip the generic QuotaExceeded/QuotaCritical here so the widget doesn't
+     * show two bullets for the same underlying condition. Other quotas
+     * (users, staff, inscriptions, storage) always flow through normally.
+     */
+    private function collectQuotaAlerts(Tenant $tenant, array &$health, bool $planMismatchFired = false): void
     {
-        $quotaPct = $this->computeQuotaPercentages($tenant);
+        $quotaPct = $this->computeQuotaPercentages($tenant, skipStudents: $planMismatchFired);
 
         if ($quotaPct['max'] >= 100) {
             $health['quota_exceeded_count']++;
@@ -524,7 +573,129 @@ class TenantAggregationService
         }
     }
 
-    private function computeQuotaPercentages(Tenant $tenant): array
+    /**
+     * Returns true when a PlanMismatch alert was emitted (so the caller can
+     * suppress the generic QuotaExceeded for the students quota). Warning
+     * fires at >=warning_pct, Critical fires at >=critical_pct (default
+     * 100% and 110% — the gap lets a tenant sit briefly "at limit" without
+     * looking red immediately after a spike).
+     */
+    private function collectPlanMismatchAlerts(Tenant $tenant, array &$health): bool
+    {
+        if ($tenant->max_students <= 0) {
+            return false;
+        }
+
+        $pct = ($tenant->current_students / $tenant->max_students) * 100;
+        $warningPct = (float) config('group_portal.plan_overage_warning_pct', 100);
+        $criticalPct = (float) config('group_portal.plan_overage_critical_pct', 110);
+
+        if ($pct < $warningPct) {
+            return false;
+        }
+
+        $severity = $pct >= $criticalPct ? AlertSeverity::Critical : AlertSeverity::Warning;
+        $planLabel = $tenant->plan ? ucfirst($tenant->plan) : 'Actuel';
+        $message = "Plan {$planLabel} dépassé — {$tenant->current_students}/{$tenant->max_students} étudiants. Passer au palier supérieur.";
+
+        $health['alerts'][] = $this->buildAlert($tenant, $severity, AlertType::PlanMismatch, $message);
+        $health['plan_overage_count']++;
+
+        return true;
+    }
+
+    /**
+     * Two mutually-exclusive outcomes per tenant: `unhealthy` (latest overall
+     * check failed → Critical) takes precedence over `stale` (last_deployed_at
+     * older than threshold → Warning). Resolver returns null when neither
+     * applies, keeping the noise out of the alerts list.
+     */
+    private function collectStaleTenantAlerts(Tenant $tenant, array &$health): void
+    {
+        $tier = $this->healthResolver->resolveStaleTier($tenant, $tenant->latestHealthCheck);
+
+        if ($tier === null) {
+            return;
+        }
+
+        $severity = $this->healthResolver->severityForStaleTier($tier);
+
+        if ($tier === HealthCheckAlertResolver::STALE_TIER_UNHEALTHY) {
+            $health['unhealthy_tenant_count']++;
+            $detail = $tenant->latestHealthCheck?->details ?: 'aucun détail';
+            $message = "Health check échec : {$detail}";
+        } else {
+            $health['stale_tenant_count']++;
+            $days = $tenant->last_deployed_at
+                ? (int) $tenant->last_deployed_at->diffInDays(now())
+                : 0;
+            $message = "Tenant inactif depuis {$days} jours (dernier déploiement).";
+        }
+
+        $health['alerts'][] = $this->buildAlert($tenant, $severity, AlertType::StaleTenant, $message);
+    }
+
+    /**
+     * Reads `metadata.days_remaining` from the latest ssl_certificate check
+     * (already computed by the health-check command — don't re-parse
+     * `expires_at` here). Thresholds default to 15/7 days, more conservative
+     * than the per-tenant health status flip (30/7).
+     */
+    private function collectSslExpiryAlerts(Tenant $tenant, array &$health): void
+    {
+        $tier = $this->healthResolver->resolveSslTier($tenant->latestSslHealthCheck);
+
+        if ($tier === null) {
+            return;
+        }
+
+        $severity = $this->healthResolver->severityForSslTier($tier);
+        $days = (int) ($tenant->latestSslHealthCheck->metadata['days_remaining'] ?? 0);
+
+        if ($tier === HealthCheckAlertResolver::SSL_TIER_CRITICAL) {
+            $health['ssl_critical_count']++;
+        } else {
+            $health['ssl_expiring_count']++;
+        }
+
+        $message = "Certificat SSL expire dans {$days} jour" . ($days > 1 ? 's' : '') . '.';
+        $health['alerts'][] = $this->buildAlert($tenant, $severity, AlertType::SslExpiring, $message);
+    }
+
+    /**
+     * $monthlyData shape: ['current' => int, 'previous' => int, 'two_months_ago' => int]
+     * Returned by computeTenantMonthlyEnrollments — when the tenant query
+     * fails, the value is null and we skip the alert silently (logging was
+     * already done inside computeTenantMonthlyEnrollments).
+     */
+    private function collectEnrollmentDeclineAlerts(Tenant $tenant, array &$health, ?array $monthlyData): void
+    {
+        if ($monthlyData === null) {
+            return;
+        }
+
+        $result = $this->enrollmentAnalyzer->detectDecline(
+            (int) ($monthlyData['current'] ?? 0),
+            (int) ($monthlyData['previous'] ?? 0),
+            (int) ($monthlyData['two_months_ago'] ?? 0)
+        );
+
+        if ($result === null) {
+            return;
+        }
+
+        $health['enrollment_decline_count']++;
+        $message = "Inscriptions en baisse : -{$result['drop_pct_current']}% vs mois dernier, -{$result['drop_pct_previous']}% le mois précédent.";
+
+        $health['alerts'][] = $this->buildAlert(
+            $tenant,
+            AlertSeverity::Warning,
+            AlertType::EnrollmentDecline,
+            $message
+        );
+    }
+
+    private function computeQuotaPercentages(Tenant $tenant, bool $skipStudents = false): array
     {
         $usagePct = [];
 
@@ -534,7 +705,7 @@ class TenantAggregationService
         if ($tenant->max_staff > 0) {
             $usagePct['staff'] = round(($tenant->current_staff / $tenant->max_staff) * 100, 1);
         }
-        if ($tenant->max_students > 0) {
+        if (! $skipStudents && $tenant->max_students > 0) {
             $usagePct['students'] = round(($tenant->current_students / $tenant->max_students) * 100, 1);
         }
         if ($tenant->max_inscriptions_per_year > 0) {
@@ -725,6 +896,52 @@ class TenantAggregationService
         } catch (\Exception $e) {
             Log::error("[group-refactor] computeTenantTrends failed for {$tenant->code}: {$e->getMessage()}");
             return $this->emptyTrends();
+        } finally {
+            if ($conn !== null) {
+                $this->connectionManager->closeConnection($conn);
+            }
+        }
+    }
+
+    /**
+     * Counts new inscriptions in the current, previous, and month-before
+     * windows — feeds `EnrollmentTrendAnalyzer` for PR7b decline detection.
+     *
+     * @param  ?PeriodInterface  $period  Accepted for uniform aggregator call shape — IGNORED.
+     *                                    Windows are calendar-month-relative (Carbon now()),
+     *                                    not period-relative, because the decline check is
+     *                                    a rolling-window signal that shouldn't shift when
+     *                                    the user scrolls the Period selector.
+     *
+     * @return array{current: int, previous: int, two_months_ago: int}
+     */
+    public function computeTenantMonthlyEnrollments(Tenant $tenant, ?PeriodInterface $period = null): array
+    {
+        $empty = ['current' => 0, 'previous' => 0, 'two_months_ago' => 0];
+
+        $conn = null;
+        try {
+            $conn = $this->connectionManager->createConnection($tenant);
+
+            $currentStart = now()->startOfMonth();
+            $previousStart = now()->subMonth()->startOfMonth();
+            $twoMonthsAgoStart = now()->subMonths(2)->startOfMonth();
+
+            $count = fn ($from, $to) => DB::connection($conn)
+                ->table('esbtp_inscriptions')
+                ->whereBetween('created_at', [$from, $to])
+                ->where('status', 'active')
+                ->where('workflow_step', 'etudiant_cree')
+                ->count();
+
+            return [
+                'current' => $count($currentStart, now()),
+                'previous' => $count($previousStart, $currentStart->copy()->subSecond()),
+                'two_months_ago' => $count($twoMonthsAgoStart, $previousStart->copy()->subSecond()),
+            ];
+        } catch (\Exception $e) {
+            Log::error("[group-refactor] computeTenantMonthlyEnrollments failed for {$tenant->code}: {$e->getMessage()}");
+            return $empty;
         } finally {
             if ($conn !== null) {
                 $this->connectionManager->closeConnection($conn);

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -71,4 +71,38 @@ return [
     'subscription_urgent_days' => env('GROUP_PORTAL_SUBSCRIPTION_URGENT_DAYS', 7),
     'subscription_warning_days' => env('GROUP_PORTAL_SUBSCRIPTION_WARNING_DAYS', 14),
     'subscription_info_days' => env('GROUP_PORTAL_SUBSCRIPTION_INFO_DAYS', 30),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Health alerts (PR7b)
+    |--------------------------------------------------------------------------
+    |
+    | Additional group-level alerts surfaced in GroupAlertsWidget (NOT the
+    | permanent banner — that remains reserved for subscription expiry).
+    | Four families: plan overage, stale tenant, SSL cert expiry, enrollment
+    | decline. Single coarse kill switch (per-alert toggles proved ops burden
+    | without operational gain in review).
+    |
+    |   GROUP_PORTAL_HEALTH_ALERTS_ENABLED=false
+    |
+    | PlanMismatch replaces the generic QuotaExceeded alert for the `students`
+    | quota specifically — the message is richer (plan name + upgrade hint).
+    | Other quotas (users, staff, storage) still flow through QuotaExceeded.
+    */
+    'health_alerts_enabled' => env('GROUP_PORTAL_HEALTH_ALERTS_ENABLED', true),
+
+    'plan_overage_warning_pct' => env('GROUP_PORTAL_PLAN_OVERAGE_WARNING_PCT', 100),
+    'plan_overage_critical_pct' => env('GROUP_PORTAL_PLAN_OVERAGE_CRITICAL_PCT', 110),
+
+    'stale_tenant_days' => env('GROUP_PORTAL_STALE_TENANT_DAYS', 30),
+
+    // Group-level SSL thresholds are intentionally more conservative than the
+    // per-tenant TenantHealthCheck thresholds (30/7) so the founder is alerted
+    // before any single tenant flips to degraded/unhealthy status.
+    'ssl_expiry_warning_days' => env('GROUP_PORTAL_SSL_EXPIRY_WARNING_DAYS', 15),
+    'ssl_expiry_critical_days' => env('GROUP_PORTAL_SSL_EXPIRY_CRITICAL_DAYS', 7),
+
+    // Single-month dips are noise; the two-consecutive-months requirement in
+    // EnrollmentTrendAnalyzer filters for genuine trends.
+    'enrollment_decline_threshold_pct' => env('GROUP_PORTAL_ENROLLMENT_DECLINE_THRESHOLD_PCT', 10),
 ];

--- a/tests/Feature/Group/HealthAlertsStructuralTest.php
+++ b/tests/Feature/Group/HealthAlertsStructuralTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Enums\AlertType;
+
+/**
+ * Structural tests for the PR7b health alerts integration. Behavior on real
+ * tenants requires cross-database fixtures and is covered by the per-resolver
+ * unit tests plus the visual check on `/groupe`.
+ */
+
+it('AlertType enum carries the 4 new PR7b cases', function () {
+    expect(AlertType::PlanMismatch->value)->toBe('plan_mismatch');
+    expect(AlertType::StaleTenant->value)->toBe('stale_tenant');
+    expect(AlertType::SslExpiring->value)->toBe('ssl_expiring');
+    expect(AlertType::EnrollmentDecline->value)->toBe('enrollment_decline');
+});
+
+it('health alerts config defaults match the PR7b contract', function () {
+    expect(config('group_portal.health_alerts_enabled'))->toBe(true);
+    expect((int) config('group_portal.plan_overage_warning_pct'))->toBe(100);
+    expect((int) config('group_portal.plan_overage_critical_pct'))->toBe(110);
+    expect((int) config('group_portal.stale_tenant_days'))->toBe(30);
+    expect((int) config('group_portal.ssl_expiry_warning_days'))->toBe(15);
+    expect((int) config('group_portal.ssl_expiry_critical_days'))->toBe(7);
+    expect((int) config('group_portal.enrollment_decline_threshold_pct'))->toBe(10);
+});
+
+it('Tenant model exposes the two latestOfMany relations used by PR7b', function () {
+    $source = file_get_contents(app_path('Models/Tenant.php'));
+
+    expect($source)->toContain('public function latestHealthCheck()');
+    expect($source)->toContain('latestOfMany(\'checked_at\')');
+    expect($source)->toContain('public function latestSslHealthCheck()');
+    expect($source)->toContain("'ssl_certificate'");
+});
+
+it('TenantAggregationService wires the 4 PR7b collectors behind the kill switch', function () {
+    $source = file_get_contents(app_path('Services/TenantAggregationService.php'));
+
+    expect($source)->toContain("config('group_portal.health_alerts_enabled'");
+    expect($source)->toContain('collectPlanMismatchAlerts');
+    expect($source)->toContain('collectStaleTenantAlerts');
+    expect($source)->toContain('collectSslExpiryAlerts');
+    expect($source)->toContain('collectEnrollmentDeclineAlerts');
+    expect($source)->toContain('computeTenantMonthlyEnrollments');
+});
+
+it('PlanMismatch collector suppresses the duplicate QuotaExceeded for students', function () {
+    $source = file_get_contents(app_path('Services/TenantAggregationService.php'));
+
+    // collectQuotaAlerts accepts $planMismatchFired, forwarding to skipStudents
+    $pattern = '/collectQuotaAlerts\(\s*Tenant\s+\$tenant,\s*array\s+&\$health,'
+        . '\s*bool\s+\$planMismatchFired\s*=\s*false\)/';
+    expect(preg_match($pattern, $source))->toBe(1);
+
+    // computeQuotaPercentages honours the skipStudents flag
+    expect($source)->toContain('skipStudents: $planMismatchFired');
+    expect($source)->toContain('if (! $skipStudents && $tenant->max_students > 0)');
+});
+
+it('SSL collector reads metadata.days_remaining (not expires_at or response_metadata)', function () {
+    $source = file_get_contents(app_path('Services/TenantAggregationService.php'));
+
+    expect($source)->toContain("metadata['days_remaining']");
+    expect($source)->not->toContain('response_metadata');
+});
+
+it('health alerts loop eager-loads the two relations to avoid N+1', function () {
+    $source = file_get_contents(app_path('Services/TenantAggregationService.php'));
+
+    expect($source)->toContain("load(['latestHealthCheck', 'latestSslHealthCheck'])");
+});
+
+it('HealthCheckAlertResolver exposes the expected tier constants', function () {
+    expect(\App\Services\Group\HealthCheckAlertResolver::SSL_TIER_CRITICAL)->toBe('critical');
+    expect(\App\Services\Group\HealthCheckAlertResolver::SSL_TIER_WARNING)->toBe('warning');
+    expect(\App\Services\Group\HealthCheckAlertResolver::STALE_TIER_UNHEALTHY)->toBe('unhealthy');
+    expect(\App\Services\Group\HealthCheckAlertResolver::STALE_TIER_STALE)->toBe('stale');
+});
+
+it('EnrollmentTrendAnalyzer is instantiable via the container', function () {
+    $analyzer = app(\App\Services\Group\EnrollmentTrendAnalyzer::class);
+
+    expect($analyzer)->toBeInstanceOf(\App\Services\Group\EnrollmentTrendAnalyzer::class);
+});
+
+it('TenantAggregationService auto-injects the two new resolvers via the constructor', function () {
+    $service = app(\App\Services\TenantAggregationService::class);
+
+    expect($service)->toBeInstanceOf(\App\Services\TenantAggregationService::class);
+});

--- a/tests/Unit/Services/Group/EnrollmentTrendAnalyzerTest.php
+++ b/tests/Unit/Services/Group/EnrollmentTrendAnalyzerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Services\Group\EnrollmentTrendAnalyzer;
+
+beforeEach(function () {
+    config()->set('group_portal.enrollment_decline_threshold_pct', 10);
+});
+
+it('flags a decline when both consecutive months drop above the threshold', function () {
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // 100 → 80 (20% drop) → 60 (25% drop) — both exceed 10%
+    $result = $analyzer->detectDecline(60, 80, 100);
+
+    expect($result)->not->toBeNull();
+    expect($result['declining'])->toBeTrue();
+    expect($result['drop_pct_current'])->toBe(25.0);
+    expect($result['drop_pct_previous'])->toBe(20.0);
+});
+
+it('returns null when only the current month drops below the threshold', function () {
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // 100 → 95 (5% drop) → 70 (26% drop in curr) — previous drop < 10%
+    expect($analyzer->detectDecline(70, 95, 100))->toBeNull();
+});
+
+it('returns null when only the previous month drops below the threshold', function () {
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // 100 → 80 (20% drop in prev) → 76 (5% drop in curr) — current drop < 10%
+    expect($analyzer->detectDecline(76, 80, 100))->toBeNull();
+});
+
+it('returns null when the enrollment is growing', function () {
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // 100 → 110 → 120 (growth, no decline)
+    expect($analyzer->detectDecline(120, 110, 100))->toBeNull();
+});
+
+it('returns null when baseline months are zero (no data to compare)', function () {
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    expect($analyzer->detectDecline(0, 0, 0))->toBeNull();
+    expect($analyzer->detectDecline(5, 0, 10))->toBeNull();
+    expect($analyzer->detectDecline(5, 10, 0))->toBeNull();
+});
+
+it('honours overridden threshold from config', function () {
+    config()->set('group_portal.enrollment_decline_threshold_pct', 5);
+
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // 100 → 93 (7%) → 86 (7.5%) — above 5%, would not flag at default 10%
+    $result = $analyzer->detectDecline(86, 93, 100);
+
+    expect($result)->not->toBeNull();
+    expect($result['declining'])->toBeTrue();
+});
+
+it('returns null for exactly the threshold value (strict comparison)', function () {
+    config()->set('group_portal.enrollment_decline_threshold_pct', 10);
+
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // Exactly 10% drop on both — strict < threshold means flagged
+    $result = $analyzer->detectDecline(81, 90, 100);
+
+    expect($result)->not->toBeNull();
+});

--- a/tests/Unit/Services/Group/HealthCheckAlertResolverTest.php
+++ b/tests/Unit/Services/Group/HealthCheckAlertResolverTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Enums\AlertSeverity;
+use App\Models\Tenant;
+use App\Models\TenantHealthCheck;
+use App\Services\Group\HealthCheckAlertResolver;
+use Illuminate\Support\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-04-21 10:00:00');
+
+    config()->set('group_portal.ssl_expiry_warning_days', 15);
+    config()->set('group_portal.ssl_expiry_critical_days', 7);
+    config()->set('group_portal.stale_tenant_days', 30);
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+function sslCheck(?int $daysRemaining): TenantHealthCheck
+{
+    $check = new TenantHealthCheck();
+    $check->setRawAttributes([
+        'check_type' => 'ssl_certificate',
+        'status' => 'healthy',
+        'metadata' => $daysRemaining !== null
+            ? json_encode(['days_remaining' => $daysRemaining])
+            : null,
+        'checked_at' => '2026-04-21 09:00:00',
+    ], true);
+
+    return $check;
+}
+
+function tenantWithDeploy(?string $deployedAt, string $name = 'Fixture'): Tenant
+{
+    $tenant = new Tenant();
+    $tenant->setRawAttributes([
+        'name' => $name,
+        'code' => 'fixture',
+        'last_deployed_at' => $deployedAt,
+    ], true);
+
+    return $tenant;
+}
+
+it('SSL returns null when the latest ssl check is missing', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveSslTier(null))->toBeNull();
+});
+
+it('SSL returns null when metadata.days_remaining is missing', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveSslTier(sslCheck(null)))->toBeNull();
+});
+
+it('SSL returns null when days_remaining is beyond the warning threshold', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveSslTier(sslCheck(16)))->toBeNull();
+    expect($resolver->resolveSslTier(sslCheck(45)))->toBeNull();
+});
+
+it('SSL returns warning between critical+1 and warning thresholds', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveSslTier(sslCheck(15)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_WARNING);
+    expect($resolver->resolveSslTier(sslCheck(8)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_WARNING);
+});
+
+it('SSL returns critical at or below the critical threshold', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveSslTier(sslCheck(7)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_CRITICAL);
+    expect($resolver->resolveSslTier(sslCheck(0)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_CRITICAL);
+    expect($resolver->resolveSslTier(sslCheck(-3)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_CRITICAL);
+});
+
+it('SSL honours overridden thresholds from config', function () {
+    config()->set('group_portal.ssl_expiry_warning_days', 45);
+    config()->set('group_portal.ssl_expiry_critical_days', 20);
+
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveSslTier(sslCheck(30)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_WARNING);
+    expect($resolver->resolveSslTier(sslCheck(20)))
+        ->toBe(HealthCheckAlertResolver::SSL_TIER_CRITICAL);
+});
+
+it('stale returns null when last_deployed_at is unset (never deployed is not stale)', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->resolveStaleTier(tenantWithDeploy(null), null))->toBeNull();
+});
+
+it('stale returns stale when last deployment is older than threshold', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    // 35 days ago
+    expect($resolver->resolveStaleTier(tenantWithDeploy('2026-03-17 10:00:00'), null))
+        ->toBe(HealthCheckAlertResolver::STALE_TIER_STALE);
+});
+
+it('stale returns null when last deployment is recent', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    // 5 days ago
+    expect($resolver->resolveStaleTier(tenantWithDeploy('2026-04-16 10:00:00'), null))
+        ->toBeNull();
+});
+
+it('unhealthy status takes precedence over stale deployment', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    $unhealthyCheck = new TenantHealthCheck();
+    $unhealthyCheck->setRawAttributes([
+        'check_type' => 'http_status',
+        'status' => 'unhealthy',
+        'checked_at' => '2026-04-21 09:00:00',
+    ], true);
+
+    // Deploy was 2 days ago (not stale) but latest check says unhealthy
+    expect($resolver->resolveStaleTier(tenantWithDeploy('2026-04-19 10:00:00'), $unhealthyCheck))
+        ->toBe(HealthCheckAlertResolver::STALE_TIER_UNHEALTHY);
+});
+
+it('maps SSL tiers to the expected severities', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->severityForSslTier(HealthCheckAlertResolver::SSL_TIER_CRITICAL))
+        ->toBe(AlertSeverity::Critical);
+    expect($resolver->severityForSslTier(HealthCheckAlertResolver::SSL_TIER_WARNING))
+        ->toBe(AlertSeverity::Warning);
+});
+
+it('maps stale tiers to the expected severities', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    expect($resolver->severityForStaleTier(HealthCheckAlertResolver::STALE_TIER_UNHEALTHY))
+        ->toBe(AlertSeverity::Critical);
+    expect($resolver->severityForStaleTier(HealthCheckAlertResolver::STALE_TIER_STALE))
+        ->toBe(AlertSeverity::Warning);
+});


### PR DESCRIPTION
## Summary

Extend \`GroupAlertsWidget\` with 4 new alert families (NOT the permanent banner — that remains reserved for subscription expiry, PR7a).

- **PlanMismatch** — \`current_students > max_students\` → Warning ≥100%, Critical ≥110%. **Replaces** \`QuotaExceeded\` for students specifically (richer message with plan name + upgrade hint). \`collectQuotaAlerts\` now skips students when PlanMismatch fires (no duplicate).
- **StaleTenant** — \`last_deployed_at > 30 days\` → Warning, OR latest health check \`status = 'unhealthy'\` → Critical. Unhealthy takes precedence (no double alert).
- **SslExpiring** — reads \`metadata.days_remaining\` from the latest \`ssl_certificate\` health check (column is \`metadata\`, NOT the \`response_metadata\` from the initial plan). Thresholds 15/7 more conservative than tenant-level 30/7.
- **EnrollmentDecline** — two consecutive months of MoM drop > 10% (configurable). Noise filter vs seasonal single-month dips.

## Architecture

- \`HealthCheckAlertResolver\` + \`EnrollmentTrendAnalyzer\` as pure services (SRP, same shape as \`SubscriptionTierResolver\` from PR7a — no DB, unit-testable).
- \`Tenant::latestHealthCheck()\` / \`latestSslHealthCheck()\` via \`hasOne()->latestOfMany()\` — eager-loaded once per group call to avoid N+1.
- \`computeTenantMonthlyEnrollments()\` fans out via the existing aggregator pattern (3 months of new-inscription counts per tenant).
- Single kill switch \`GROUP_PORTAL_HEALTH_ALERTS_ENABLED\` (per-alert toggles deemed ops burden without operational gain in the critic review).

## Critic review + corrections appliquées

Initial plan had 3 blockers flagged by the \`/plan-and-confirm\` critic (verdict: RETHINK):
- \`response_metadata\` → **corrigé** \`metadata\` (la vraie colonne)
- \`SubscriptionPlan.limits.max_students\` → **corrigé** \`tenants.max_students\` (flat column, source of truth)
- \`PlanMismatch\` duplique \`QuotaExceeded\` → **corrigé** : skip students dans \`collectQuotaAlerts\` quand PlanMismatch fire

Plus : N+1 fix via \`latestOfMany()\`, enrollment decline défini sur 2 mois consécutifs (pas 1).

## Test Plan

- [x] Unit tests HealthCheckAlertResolver : 12 tests
- [x] Unit tests EnrollmentTrendAnalyzer : 7 tests
- [x] Feature structural tests : 10 tests (enum cases, config defaults, source patterns, DI)
- [x] **Total PR7b : 29 nouveaux tests, 115 tests groupe passent (324 assertions), 0 régression**
- [ ] Visual check à faire post-merge : GroupAlertsWidget affiche bien les 4 nouveaux types

## Quality Gate — 4 Axes

| Axe | Verdict |
|-----|---------|
| Architecture | PASS — SRP respecté (2 services purs), même pattern que SubscriptionTierResolver PR7a, constructor injection |
| Qualité vs Vitesse | PASS — 29 tests (4+ par alerte vs 2 min demandés), N+1 fixé via \`latestOfMany()\`, aggregator pre-load |
| Production-grade | PASS — kill switch + seuils config, graceful degradation (null-safe), alignement avec seuils SSL existants |
| SOLID | PASS — Open/Closed (resolvers ajoutables sans toucher service core), ISP (signatures services minimales) |

## Files

**Nouveaux (5)** :
- \`app/Services/Group/HealthCheckAlertResolver.php\`
- \`app/Services/Group/EnrollmentTrendAnalyzer.php\`
- \`tests/Unit/Services/Group/HealthCheckAlertResolverTest.php\` (12 tests)
- \`tests/Unit/Services/Group/EnrollmentTrendAnalyzerTest.php\` (7 tests)
- \`tests/Feature/Group/HealthAlertsStructuralTest.php\` (10 tests)

**Modifiés (4)** :
- \`app/Enums/AlertType.php\` — 4 nouveaux cases
- \`app/Models/Tenant.php\` — 2 relations \`latestOfMany()\`
- \`app/Services/TenantAggregationService.php\` — 4 collectors + eager-load + skip students quota + \`computeTenantMonthlyEnrollments()\`
- \`config/group_portal.php\` — kill switch + 6 seuils

Closes #35