### PR TITLE
chore(group-portal): PR7a/b tech debt cleanup (DTO + SSL guard + test name)

### DIFF
--- a/app/Services/Group/EnrollmentDeclineResult.php
+++ b/app/Services/Group/EnrollmentDeclineResult.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services\Group;
+
+/**
+ * Immutable result of `EnrollmentTrendAnalyzer::detectDecline()`.
+ *
+ * Returned only when a decline is detected — callers get `null` for the
+ * no-decline case, so the presence of an instance IS the "declining = true"
+ * signal. Named properties replace the fragile array-key access pattern
+ * (`$result['drop_pct_current']`) that would silently null-coalesce on typos.
+ */
+final readonly class EnrollmentDeclineResult
+{
+    public function __construct(
+        public float $dropPctCurrent,
+        public float $dropPctPrevious,
+    ) {
+    }
+}

--- a/app/Services/Group/EnrollmentTrendAnalyzer.php
+++ b/app/Services/Group/EnrollmentTrendAnalyzer.php
@@ -18,15 +18,15 @@ class EnrollmentTrendAnalyzer
     /**
      * Analyses a three-month window of new-inscription counts.
      *
-     * @param  int  $currentMonth     New inscriptions in the current calendar month.
-     * @param  int  $previousMonth    New inscriptions in the previous calendar month.
-     * @param  int  $twoMonthsAgo     New inscriptions two calendar months back.
+     * Returns null when no decline is detected. The presence of an
+     * `EnrollmentDeclineResult` instance IS the "declining" signal — no
+     * redundant boolean flag, no typo-prone array keys.
      *
-     * @return array{declining: bool, drop_pct_current: ?float, drop_pct_previous: ?float}|null
-     *         Null when no decline is detected. When declining, returns both
-     *         drop percentages so the caller can build a precise alert message.
+     * @param  int  $currentMonth   New inscriptions in the current calendar month.
+     * @param  int  $previousMonth  New inscriptions in the previous calendar month.
+     * @param  int  $twoMonthsAgo   New inscriptions two calendar months back.
      */
-    public function detectDecline(int $currentMonth, int $previousMonth, int $twoMonthsAgo): ?array
+    public function detectDecline(int $currentMonth, int $previousMonth, int $twoMonthsAgo): ?EnrollmentDeclineResult
     {
         if ($previousMonth === 0 || $twoMonthsAgo === 0) {
             return null;
@@ -41,11 +41,10 @@ class EnrollmentTrendAnalyzer
             return null;
         }
 
-        return [
-            'declining' => true,
-            'drop_pct_current' => round($dropCurrent, 1),
-            'drop_pct_previous' => round($dropPrevious, 1),
-        ];
+        return new EnrollmentDeclineResult(
+            dropPctCurrent: round($dropCurrent, 1),
+            dropPctPrevious: round($dropPrevious, 1),
+        );
     }
 
     /**

--- a/app/Services/Group/HealthCheckAlertResolver.php
+++ b/app/Services/Group/HealthCheckAlertResolver.php
@@ -44,6 +44,13 @@ class HealthCheckAlertResolver
             return null;
         }
 
+        // Guard against corrupted metadata where `days_remaining` is a string
+        // like "expired" or null — silent `(int)` coercion would produce 0 and
+        // fire a phantom Critical alert ("expire dans 0 jour").
+        if (! is_numeric($metadata['days_remaining'])) {
+            return null;
+        }
+
         $days = (int) $metadata['days_remaining'];
 
         if ($days <= (int) config('group_portal.ssl_expiry_critical_days', 7)) {

--- a/app/Services/TenantAggregationService.php
+++ b/app/Services/TenantAggregationService.php
@@ -685,7 +685,7 @@ class TenantAggregationService
         }
 
         $health['enrollment_decline_count']++;
-        $message = "Inscriptions en baisse : -{$result['drop_pct_current']}% vs mois dernier, -{$result['drop_pct_previous']}% le mois précédent.";
+        $message = "Inscriptions en baisse : -{$result->dropPctCurrent}% vs mois dernier, -{$result->dropPctPrevious}% le mois précédent.";
 
         $health['alerts'][] = $this->buildAlert(
             $tenant,

--- a/tests/Unit/Services/Group/EnrollmentTrendAnalyzerTest.php
+++ b/tests/Unit/Services/Group/EnrollmentTrendAnalyzerTest.php
@@ -12,10 +12,9 @@ it('flags a decline when both consecutive months drop above the threshold', func
     // 100 → 80 (20% drop) → 60 (25% drop) — both exceed 10%
     $result = $analyzer->detectDecline(60, 80, 100);
 
-    expect($result)->not->toBeNull();
-    expect($result['declining'])->toBeTrue();
-    expect($result['drop_pct_current'])->toBe(25.0);
-    expect($result['drop_pct_previous'])->toBe(20.0);
+    expect($result)->toBeInstanceOf(\App\Services\Group\EnrollmentDeclineResult::class);
+    expect($result->dropPctCurrent)->toBe(25.0);
+    expect($result->dropPctPrevious)->toBe(20.0);
 });
 
 it('returns null when only the current month drops below the threshold', function () {
@@ -55,17 +54,26 @@ it('honours overridden threshold from config', function () {
     // 100 → 93 (7%) → 86 (7.5%) — above 5%, would not flag at default 10%
     $result = $analyzer->detectDecline(86, 93, 100);
 
-    expect($result)->not->toBeNull();
-    expect($result['declining'])->toBeTrue();
+    expect($result)->toBeInstanceOf(\App\Services\Group\EnrollmentDeclineResult::class);
 });
 
-it('returns null for exactly the threshold value (strict comparison)', function () {
+it('flags exactly the threshold value (inclusive boundary, strict less-than filter)', function () {
     config()->set('group_portal.enrollment_decline_threshold_pct', 10);
 
     $analyzer = new EnrollmentTrendAnalyzer();
 
-    // Exactly 10% drop on both — strict < threshold means flagged
+    // Exactly 10% drop on both months. Source filter is `$drop < $threshold`,
+    // so a 10% drop is NOT filtered out — the boundary is inclusive on flag side.
     $result = $analyzer->detectDecline(81, 90, 100);
 
-    expect($result)->not->toBeNull();
+    expect($result)->toBeInstanceOf(\App\Services\Group\EnrollmentDeclineResult::class);
+});
+
+it('returns null just below the threshold (9.99%)', function () {
+    config()->set('group_portal.enrollment_decline_threshold_pct', 10);
+
+    $analyzer = new EnrollmentTrendAnalyzer();
+
+    // 100 → 90.01 (9.99% drop) → 81.00 (10.00% drop) — first month just below threshold
+    expect($analyzer->detectDecline(81, 9001, 10000))->toBeNull();
 });

--- a/tests/Unit/Services/Group/HealthCheckAlertResolverTest.php
+++ b/tests/Unit/Services/Group/HealthCheckAlertResolverTest.php
@@ -57,6 +57,25 @@ it('SSL returns null when metadata.days_remaining is missing', function () {
     expect($resolver->resolveSslTier(sslCheck(null)))->toBeNull();
 });
 
+it('SSL returns null when metadata.days_remaining is non-numeric (corrupted payload)', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    // The health-check command should always write an integer, but defensive
+    // guarding avoids a phantom Critical "expire dans 0 jour" if the payload
+    // ever ships "expired" / null / "N/A" as the value.
+    foreach (['expired', 'N/A', '', null] as $badValue) {
+        $check = new TenantHealthCheck();
+        $check->setRawAttributes([
+            'check_type' => 'ssl_certificate',
+            'status' => 'healthy',
+            'metadata' => json_encode(['days_remaining' => $badValue]),
+            'checked_at' => '2026-04-21 09:00:00',
+        ], true);
+
+        expect($resolver->resolveSslTier($check))->toBeNull();
+    }
+});
+
 it('SSL returns null when days_remaining is beyond the warning threshold', function () {
     $resolver = new HealthCheckAlertResolver();
 


### PR DESCRIPTION
## Summary

Three low-risk follow-ups from the PR7b review agents. Non-breaking.

- **DTO** — Replace `EnrollmentTrendAnalyzer::detectDecline()` array return with readonly `EnrollmentDeclineResult` class. Presence = declining signal, property access = no typo risk.
- **SSL guard** — `HealthCheckAlertResolver::resolveSslTier()` now returns null if `metadata.days_remaining` is non-numeric (prevents phantom "expire dans 0 jour" on corrupted payload).
- **Test rename** — `EnrollmentTrendAnalyzerTest` test name corrected + new 9.99% symmetric test.

## Skipped (documented rationale)

- **D1 enum migration** — cache-compat risk (Blade match against cached strings → `UnhandledMatchError`) outweighs internal-only benefit.
- **D5 null-coalesce** — false positive: `current_students` is `NOT NULL DEFAULT 0` per migration.

## Tests

117 pass (+2), 327 assertions, 0 regression.

## Type

chore