### PR TITLE
feat(group-portal): toutes les alertes index page

### DIFF
--- a/app/Filament/Group/Pages/AlertsIndex.php
+++ b/app/Filament/Group/Pages/AlertsIndex.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Filament\Group\Pages;
+
+use App\Filament\Group\Concerns\HasCustomHero;
+use App\Services\TenantAggregationService;
+use Filament\Pages\Page;
+
+/**
+ * Full-page view of every alert the group portal surfaces, complementing the
+ * `GroupAlertsWidget` which shows only the top 5 on the dashboard. Filtering
+ * is client-side (Alpine) since the alerts payload caps at a few dozen rows
+ * in practice — cross-tenant health metrics for 20 tenants = ~40 alerts max.
+ */
+class AlertsIndex extends Page
+{
+    use HasCustomHero;
+
+    protected static ?string $navigationIcon = 'heroicon-o-bell-alert';
+
+    protected static ?string $navigationLabel = 'Alertes';
+
+    protected static ?string $navigationGroup = 'Analytiques';
+
+    protected static ?string $title = 'Toutes les alertes';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static string $view = 'filament.group.pages.alerts-index';
+
+    protected static ?string $slug = 'alertes';
+
+    /**
+     * Poll every 5 min to match `TenantAggregationService::CACHE_TTL_HEALTH`.
+     * Polling more often just re-renders the same cached payload.
+     */
+    protected ?string $pollingInterval = '300s';
+
+    public function getAlerts(): array
+    {
+        $health = $this->getHealth();
+        $alerts = $health['alerts'] ?? [];
+        $dismissed = session('gp_alerts_acknowledged', []);
+
+        // Stamp each alert with a client-stable fingerprint so the template
+        // can filter acknowledged ones without a server round-trip. Same
+        // tenant+type combo is considered the "same" alert across polls —
+        // message text changes (e.g. days remaining) don't break the ack.
+        return array_map(function (array $alert) use ($dismissed) {
+            $fingerprint = $this->fingerprintOf($alert);
+            $alert['fingerprint'] = $fingerprint;
+            $alert['acknowledged'] = isset($dismissed[$fingerprint])
+                && now()->lessThan($dismissed[$fingerprint]);
+
+            return $alert;
+        }, $alerts);
+    }
+
+    public function getStats(): array
+    {
+        $alerts = $this->getAlerts();
+
+        $counts = ['critical' => 0, 'warning' => 0, 'info' => 0];
+        $tenantsSeen = [];
+        $activeCount = 0;
+
+        foreach ($alerts as $alert) {
+            if ($alert['acknowledged']) {
+                continue;
+            }
+            $activeCount++;
+            $tenantsSeen[$alert['tenant_code']] = true;
+            $counts[$alert['severity']]++;
+        }
+
+        return [
+            'total_active' => $activeCount,
+            'total_all' => count($alerts),
+            'critical' => $counts['critical'],
+            'warning' => $counts['warning'],
+            'info' => $counts['info'],
+            'tenants_affected' => count($tenantsSeen),
+        ];
+    }
+
+    private function getHealth(): array
+    {
+        $group = auth('group')->user()->group;
+
+        return app(TenantAggregationService::class)->getGroupHealthMetrics($group);
+    }
+
+    private function fingerprintOf(array $alert): string
+    {
+        return md5(($alert['tenant_code'] ?? '') . '|' . ($alert['type'] ?? ''));
+    }
+}

--- a/public/css/groupe-portal.css
+++ b/public/css/groupe-portal.css
@@ -1604,3 +1604,195 @@
         justify-content: center;
     }
 }
+
+/* =========================================================================
+   Alerts index page (PR-B) — /groupe/alertes
+   Client-side filterable list complementing GroupAlertsWidget top-5 view.
+   ========================================================================= */
+.ga-panel {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04), 0 1px 2px rgba(15, 23, 42, 0.06);
+    padding: 1.25rem;
+    margin-top: 1.25rem;
+    font-family: var(--gp-font-body, 'DM Sans', system-ui, sans-serif);
+}
+.ga-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem 1.5rem;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid #f1f5f9;
+}
+.ga-filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+}
+.ga-filter-group--toggle {
+    margin-left: auto;
+    justify-content: flex-end;
+}
+.ga-filter-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #64748b;
+}
+.ga-chip-row {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+}
+.ga-chip {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    color: #475569;
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.ga-chip:hover {
+    background: #f1f5f9;
+    border-color: #cbd5e1;
+}
+.ga-chip--active {
+    background: #0453cb;
+    border-color: #0453cb;
+    color: #ffffff;
+}
+.ga-chip--critical.ga-chip--active {
+    background: #dc2626;
+    border-color: #dc2626;
+}
+.ga-chip--warning.ga-chip--active {
+    background: #d97706;
+    border-color: #d97706;
+}
+.ga-chip--info.ga-chip--active {
+    background: #0ea5e9;
+    border-color: #0ea5e9;
+}
+.ga-select,
+.ga-input {
+    font-family: inherit;
+    font-size: 0.85rem;
+    padding: 0.45rem 0.75rem;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    color: #0f172a;
+    min-width: 220px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.ga-select:focus,
+.ga-input:focus {
+    outline: none;
+    border-color: #0453cb;
+    box-shadow: 0 0 0 3px rgba(4, 83, 203, 0.1);
+}
+.ga-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.82rem;
+    color: #475569;
+    cursor: pointer;
+    user-select: none;
+}
+.ga-toggle input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: #0453cb;
+    cursor: pointer;
+}
+.ga-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.ga-alert {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+}
+.ga-alert[data-acknowledged="true"] {
+    opacity: 0.55;
+}
+.ga-alert-type-tag {
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.45rem;
+    background: rgba(15, 23, 42, 0.05);
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #64748b;
+}
+.ga-alert-actions {
+    flex-shrink: 0;
+}
+.ga-alert-action-form {
+    margin: 0;
+}
+.ga-btn {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    color: #475569;
+    border-radius: 8px;
+    padding: 0.4rem 0.85rem;
+    font-size: 0.76rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.ga-btn--ghost:hover {
+    background: #f8fafc;
+    border-color: #0453cb;
+    color: #0453cb;
+}
+.gp-alerts-footer {
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid #f1f5f9;
+    text-align: right;
+}
+.gp-alerts-footer-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #0453cb;
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+.gp-alerts-footer-link:hover {
+    color: #033a8e;
+    text-decoration: none;
+}
+@media (max-width: 768px) {
+    .ga-filters {
+        gap: 0.85rem;
+    }
+    .ga-filter-group--toggle {
+        margin-left: 0;
+    }
+    .ga-select,
+    .ga-input {
+        min-width: 0;
+        width: 100%;
+    }
+    .ga-alert {
+        flex-wrap: wrap;
+    }
+    .ga-alert-actions {
+        margin-left: auto;
+    }
+}

--- a/resources/views/filament/group/pages/alerts-index.blade.php
+++ b/resources/views/filament/group/pages/alerts-index.blade.php
@@ -1,0 +1,159 @@
+@php
+    use App\Enums\AlertType;
+
+    $alerts = $this->getAlerts();
+    $stats = $this->getStats();
+
+    $typeLabels = [
+        AlertType::QuotaExceeded->value => 'Quota dépassé',
+        AlertType::QuotaCritical->value => 'Quota critique',
+        AlertType::SubscriptionExpired->value => 'Abonnement expiré',
+        AlertType::SubscriptionExpiring->value => 'Abonnement expirant',
+        AlertType::HighAttrition->value => 'Attrition élevée',
+        AlertType::ActiveReliquats->value => 'Reliquats actifs',
+        AlertType::PlanMismatch->value => 'Plan dépassé',
+        AlertType::StaleTenant->value => 'Tenant inactif',
+        AlertType::SslExpiring->value => 'SSL expirant',
+        AlertType::EnrollmentDecline->value => 'Inscriptions en baisse',
+    ];
+@endphp
+
+<x-filament-panels::page>
+    <x-group-hero
+        title="Toutes les alertes"
+        subtitle="Vue consolidée des {{ $stats['total_all'] }} alerte{{ $stats['total_all'] > 1 ? 's' : '' }} détectée{{ $stats['total_all'] > 1 ? 's' : '' }} cross-établissements"
+        icon-path="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+    >
+        <x-slot:badges>
+            <span class="gp-hero-chip">Polling 5 min</span>
+            <span class="gp-hero-chip">{{ $stats['tenants_affected'] }} établissement{{ $stats['tenants_affected'] > 1 ? 's' : '' }} concerné{{ $stats['tenants_affected'] > 1 ? 's' : '' }}</span>
+        </x-slot:badges>
+
+        <x-slot:kpis>
+            <div class="gp-hero-kpi" data-tone="{{ $stats['critical'] > 0 ? 'danger' : 'neutral' }}">
+                <span class="gp-hero-kpi-label">Critiques</span>
+                <span class="gp-hero-kpi-value">{{ $stats['critical'] }}</span>
+                <span class="gp-hero-kpi-meta">action immédiate</span>
+            </div>
+            <div class="gp-hero-kpi" data-tone="{{ $stats['warning'] > 0 ? 'warning' : 'neutral' }}">
+                <span class="gp-hero-kpi-label">Avertissements</span>
+                <span class="gp-hero-kpi-value">{{ $stats['warning'] }}</span>
+                <span class="gp-hero-kpi-meta">à surveiller</span>
+            </div>
+            <div class="gp-hero-kpi">
+                <span class="gp-hero-kpi-label">Informations</span>
+                <span class="gp-hero-kpi-value">{{ $stats['info'] }}</span>
+                <span class="gp-hero-kpi-meta">pour info</span>
+            </div>
+            <div class="gp-hero-kpi">
+                <span class="gp-hero-kpi-label">Actives</span>
+                <span class="gp-hero-kpi-value">{{ $stats['total_active'] }}</span>
+                <span class="gp-hero-kpi-meta">non acquittées</span>
+            </div>
+        </x-slot:kpis>
+    </x-group-hero>
+
+    <div
+        x-data="{
+            severity: 'all',
+            type: 'all',
+            tenant: '',
+            showAcknowledged: false,
+            matches(alert) {
+                if (this.severity !== 'all' && alert.severity !== this.severity) return false;
+                if (this.type !== 'all' && alert.type !== this.type) return false;
+                if (!this.showAcknowledged && alert.acknowledged) return false;
+                if (this.tenant.trim() !== '') {
+                    const needle = this.tenant.trim().toLowerCase();
+                    if (!alert.tenant_name.toLowerCase().includes(needle)
+                        && !alert.tenant_code.toLowerCase().includes(needle)) return false;
+                }
+                return true;
+            }
+        }"
+        class="ga-panel"
+    >
+        <div class="ga-filters">
+            <div class="ga-filter-group">
+                <span class="ga-filter-label">Sévérité</span>
+                <div class="ga-chip-row">
+                    <button type="button" class="ga-chip" :class="{ 'ga-chip--active': severity === 'all' }" @click="severity = 'all'">Toutes</button>
+                    <button type="button" class="ga-chip ga-chip--critical" :class="{ 'ga-chip--active': severity === 'critical' }" @click="severity = 'critical'">Critiques</button>
+                    <button type="button" class="ga-chip ga-chip--warning" :class="{ 'ga-chip--active': severity === 'warning' }" @click="severity = 'warning'">Avertissements</button>
+                    <button type="button" class="ga-chip ga-chip--info" :class="{ 'ga-chip--active': severity === 'info' }" @click="severity = 'info'">Info</button>
+                </div>
+            </div>
+
+            <div class="ga-filter-group">
+                <label class="ga-filter-label" for="ga-type">Type</label>
+                <select id="ga-type" class="ga-select" x-model="type">
+                    <option value="all">Tous les types</option>
+                    @foreach($typeLabels as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="ga-filter-group">
+                <label class="ga-filter-label" for="ga-tenant">Établissement</label>
+                <input id="ga-tenant" type="search" class="ga-input" placeholder="Chercher par nom ou code…" x-model="tenant">
+            </div>
+
+            <div class="ga-filter-group ga-filter-group--toggle">
+                <label class="ga-toggle">
+                    <input type="checkbox" x-model="showAcknowledged">
+                    <span>Afficher acquittées</span>
+                </label>
+            </div>
+        </div>
+
+        @if(count($alerts) === 0)
+            <div class="gp-alerts-empty">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width:40px;height:40px;">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p>Aucune alerte détectée. Tous les indicateurs sont dans le vert.</p>
+            </div>
+        @else
+            <div class="ga-list">
+                @foreach($alerts as $alert)
+                    <div
+                        class="gp-alert-item gp-alert-item--{{ $alert['severity'] }} ga-alert"
+                        x-show="matches({
+                            severity: @js($alert['severity']),
+                            type: @js($alert['type']),
+                            tenant_name: @js($alert['tenant_name']),
+                            tenant_code: @js($alert['tenant_code']),
+                            acknowledged: @js($alert['acknowledged'])
+                        })"
+                        @if($alert['acknowledged']) data-acknowledged="true" @endif
+                    >
+                        <div class="gp-alert-severity-dot"></div>
+                        <div class="gp-alert-content">
+                            <div class="gp-alert-message">{{ $alert['message'] }}</div>
+                            <div class="gp-alert-tenant">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width:13px;height:13px;"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" /></svg>
+                                {{ $alert['tenant_name'] }} <span class="ga-alert-type-tag">{{ $typeLabels[$alert['type']] ?? $alert['type'] }}</span>
+                            </div>
+                        </div>
+                        <div class="ga-alert-actions">
+                            @if($alert['acknowledged'])
+                                <form method="POST" action="{{ route('groupe.alerts.unacknowledge') }}" class="ga-alert-action-form">
+                                    @csrf
+                                    <input type="hidden" name="fingerprint" value="{{ $alert['fingerprint'] }}">
+                                    <button type="submit" class="ga-btn ga-btn--ghost" title="Rétablir cette alerte">Rétablir</button>
+                                </form>
+                            @else
+                                <form method="POST" action="{{ route('groupe.alerts.acknowledge') }}" class="ga-alert-action-form">
+                                    @csrf
+                                    <input type="hidden" name="fingerprint" value="{{ $alert['fingerprint'] }}">
+                                    <button type="submit" class="ga-btn ga-btn--ghost" title="Masquer pendant 4 heures">Acquitter</button>
+                                </form>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/group/widgets/group-alerts.blade.php
+++ b/resources/views/filament/group/widgets/group-alerts.blade.php
@@ -70,5 +70,14 @@
                 <p>Aucune alerte pour le moment. Tous les indicateurs sont dans le vert.</p>
             </div>
         @endif
+
+        @if($totalAlerts > count($alerts))
+            <div class="gp-alerts-footer">
+                <a href="{{ \App\Filament\Group\Pages\AlertsIndex::getUrl() }}" class="gp-alerts-footer-link">
+                    Voir les {{ $totalAlerts }} alertes
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:14px;height:14px;"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" /></svg>
+                </a>
+            </div>
+        @endif
     </div>
 </x-filament-widgets::widget>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,3 +20,36 @@ Route::middleware(['web', 'auth:group', 'throttle:10,1'])
         return back();
     })
     ->name('groupe.subscription-banner.dismiss');
+
+// Session-scoped alert acknowledgment — alerts are ephemeral (recomputed each
+// cache cycle), so a persistent ack table would add schema + fingerprint
+// generation + cache-invalidation complexity for an unproven UX. Session
+// state with a 4h TTL mirrors the subscription banner dismiss pattern.
+Route::middleware(['web', 'auth:group', 'throttle:30,1'])
+    ->post('/groupe/alertes/acquitter', function () {
+        $fingerprint = (string) request('fingerprint', '');
+        if ($fingerprint === '') {
+            return back();
+        }
+
+        $acknowledged = session('gp_alerts_acknowledged', []);
+        $acknowledged[$fingerprint] = now()->addHours(4);
+        session()->put('gp_alerts_acknowledged', $acknowledged);
+
+        return back();
+    })
+    ->name('groupe.alerts.acknowledge');
+
+Route::middleware(['web', 'auth:group', 'throttle:30,1'])
+    ->post('/groupe/alertes/retablir', function () {
+        $fingerprint = (string) request('fingerprint', '');
+        $acknowledged = session('gp_alerts_acknowledged', []);
+
+        if ($fingerprint !== '') {
+            unset($acknowledged[$fingerprint]);
+            session()->put('gp_alerts_acknowledged', $acknowledged);
+        }
+
+        return back();
+    })
+    ->name('groupe.alerts.unacknowledge');

--- a/tests/Feature/Group/AlertsIndexPageTest.php
+++ b/tests/Feature/Group/AlertsIndexPageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Structural tests for the PR-B alerts index page. Full Livewire rendering
+ * with a seeded group requires cross-tenant DB fixtures — the visual check
+ * covers that. These tests lock the contract: page exists, routes exist,
+ * session ack shape, navigation props.
+ */
+
+it('AlertsIndex page class carries the expected Filament props', function () {
+    $page = \App\Filament\Group\Pages\AlertsIndex::class;
+
+    expect($page::getSlug())->toBe('alertes');
+
+    // Protected statics — reach via reflection.
+    $reflection = new ReflectionClass($page);
+    $title = $reflection->getStaticPropertyValue('title');
+    $group = $reflection->getStaticPropertyValue('navigationGroup');
+
+    expect($title)->toBe('Toutes les alertes');
+    expect($group)->toBe('Analytiques');
+});
+
+it('alert acknowledgment routes are registered under the group auth guard', function () {
+    foreach (['groupe.alerts.acknowledge', 'groupe.alerts.unacknowledge'] as $name) {
+        $route = Route::getRoutes()->getByName($name);
+
+        expect($route)->not->toBeNull();
+        expect($route->methods())->toContain('POST');
+        expect($route->middleware())->toContain('auth:group');
+    }
+});
+
+it('acknowledge route is rate-limited (anti-abuse on session write)', function () {
+    $route = Route::getRoutes()->getByName('groupe.alerts.acknowledge');
+
+    $middleware = $route->middleware();
+    $throttle = collect($middleware)->first(fn ($m) => str_starts_with($m, 'throttle:'));
+
+    expect($throttle)->not->toBeNull();
+});
+
+it('alerts-index view references the AlertType enum to build labels', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/pages/alerts-index.blade.php')
+    );
+
+    expect($source)->toContain('use App\\Enums\\AlertType;');
+    expect($source)->toContain('AlertType::PlanMismatch->value');
+    expect($source)->toContain('AlertType::SslExpiring->value');
+    expect($source)->toContain('AlertType::EnrollmentDecline->value');
+});
+
+it('alerts-index view implements client-side filtering via Alpine', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/pages/alerts-index.blade.php')
+    );
+
+    // Filter chips + select + search input + acknowledged toggle
+    expect($source)->toContain('x-data');
+    expect($source)->toContain('matches(alert)');
+    expect($source)->toContain("severity = 'all'");
+    expect($source)->toContain('showAcknowledged');
+});
+
+it('page fingerprint is stable across message changes for the same tenant+type', function () {
+    // Mirrors the private fingerprintOf() logic — same tenant + type = same hash
+    // regardless of days-remaining variance in the message field.
+    $alertV1 = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'message' => '10 jours'];
+    $alertV2 = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'message' => '7 jours'];
+
+    $fp = fn ($a) => md5(($a['tenant_code'] ?? '') . '|' . ($a['type'] ?? ''));
+
+    expect($fp($alertV1))->toBe($fp($alertV2));
+});
+
+it('widget view links to AlertsIndex when alerts overflow the top-5 cap', function () {
+    $source = file_get_contents(
+        resource_path('views/filament/group/widgets/group-alerts.blade.php')
+    );
+
+    expect($source)->toContain('AlertsIndex::getUrl()');
+    expect($source)->toContain('Voir les');
+    expect($source)->toContain('$totalAlerts > count($alerts)');
+});
+
+it('alerts-index CSS namespace is shipped', function () {
+    $css = file_get_contents(public_path('css/groupe-portal.css'));
+
+    expect($css)->toContain('.ga-panel');
+    expect($css)->toContain('.ga-chip--critical');
+    expect($css)->toContain('.ga-chip--warning');
+    expect($css)->toContain('.ga-chip--info');
+    expect($css)->toContain('.gp-alerts-footer-link');
+});


### PR DESCRIPTION
## Summary

Full-page companion to `GroupAlertsWidget` — page `/groupe/alertes` shows every alert with filters, complementing the widget's top-5 cap.

- New `App\Filament\Group\Pages\AlertsIndex` (Analytiques nav group, sort 5)
- Client-side Alpine filtering: severity chips, type select, tenant search, acknowledged toggle
- Session-scoped acknowledgment (4h TTL, mirrors banner dismiss) — no new schema
- Widget footer link "Voir les N alertes" when `totalAlerts > 5`
- CSS `.ga-*` namespace in `groupe-portal.css` (192 lines appended)

## Test plan

- [x] 8 structural tests (routes, enum refs, Alpine filter, fingerprint stability, CSS)
- [x] 125 group tests pass (+8 new), 0 regression
- [ ] Visual check post-merge on `/groupe/alertes` with seeded alerts

## Type

feat

Closes part of the portail-groupe-alertes-roadmap follow-ups.