### PR TITLE
feat(group-portal): PR-C founder email notifications

### DIFF
--- a/app/Console/Commands/DispatchGroupAlertNotifications.php
+++ b/app/Console/Commands/DispatchGroupAlertNotifications.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Group;
+use App\Services\Group\AlertNotificationDispatcher;
+use Illuminate\Console\Command;
+
+class DispatchGroupAlertNotifications extends Command
+{
+    protected $signature = 'group:dispatch-alert-notifications {--group= : Limit to a single group code for testing}';
+
+    protected $description = 'Dispatches immediate Critical email notifications for the group portal alerts pipeline (PR-C).';
+
+    public function handle(AlertNotificationDispatcher $dispatcher): int
+    {
+        if (! config('group_portal.notifications_enabled', false)) {
+            $this->info('group_portal.notifications_enabled is false — nothing to do.');
+            return self::SUCCESS;
+        }
+
+        $query = Group::query()->where('status', 'active');
+        if ($code = $this->option('group')) {
+            $query->where('code', $code);
+        }
+
+        $groups = $query->get();
+        $totalSent = 0;
+
+        foreach ($groups as $group) {
+            $count = $dispatcher->dispatchImmediateForGroup($group);
+            $totalSent += $count;
+
+            if ($count > 0) {
+                $this->line("[{$group->code}] dispatched {$count} critical alert(s).");
+            }
+        }
+
+        $this->info("Immediate dispatch complete — {$totalSent} email(s) sent across {$groups->count()} group(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/SendGroupAlertDigests.php
+++ b/app/Console/Commands/SendGroupAlertDigests.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Group;
+use App\Services\Group\AlertNotificationDispatcher;
+use Illuminate\Console\Command;
+
+class SendGroupAlertDigests extends Command
+{
+    protected $signature = 'group:send-alert-digests {--group= : Limit to a single group code for testing}';
+
+    protected $description = 'Sends the daily warning-alerts digest for members whose preferences match the current hour slot (PR-C).';
+
+    public function handle(AlertNotificationDispatcher $dispatcher): int
+    {
+        if (! config('group_portal.notifications_enabled', false)) {
+            $this->info('group_portal.notifications_enabled is false — nothing to do.');
+            return self::SUCCESS;
+        }
+
+        $query = Group::query()->where('status', 'active');
+        if ($code = $this->option('group')) {
+            $query->where('code', $code);
+        }
+
+        $groups = $query->get();
+        $totalSent = 0;
+
+        foreach ($groups as $group) {
+            $count = $dispatcher->dispatchDigestForGroup($group);
+            $totalSent += $count;
+
+            if ($count > 0) {
+                $this->line("[{$group->code}] sent digest to {$count} member(s).");
+            }
+        }
+
+        $this->info("Digest dispatch complete — {$totalSent} email(s) sent across {$groups->count()} group(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Mail/Group/CriticalAlertMail.php
+++ b/app/Mail/Group/CriticalAlertMail.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Mail\Group;
+
+use App\Models\Group;
+use App\Models\GroupMember;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\URL;
+
+class CriticalAlertMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public array $backoff = [30, 120, 300];
+
+    public function __construct(
+        public Group $group,
+        public GroupMember $member,
+        public array $alert,
+    ) {
+    }
+
+    public function build(): self
+    {
+        $typeLabel = $this->alert['type'] ?? 'alerte';
+        $tenant = $this->alert['tenant_name'] ?? $this->alert['tenant_code'] ?? $this->group->name;
+
+        $unsubscribeUrl = URL::signedRoute('groupe.notifications.unsubscribe', [
+            'member' => $this->member->id,
+            'type' => $typeLabel,
+        ]);
+
+        return $this->subject("[KLASSCI] Alerte critique — {$tenant}")
+            ->view('emails.group.critical-alert')
+            ->with([
+                'group' => $this->group,
+                'member' => $this->member,
+                'alert' => $this->alert,
+                'unsubscribeUrl' => $unsubscribeUrl,
+            ]);
+    }
+}

--- a/app/Mail/Group/DailyAlertDigestMail.php
+++ b/app/Mail/Group/DailyAlertDigestMail.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mail\Group;
+
+use App\Models\Group;
+use App\Models\GroupMember;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\URL;
+
+class DailyAlertDigestMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public array $backoff = [30, 120, 300];
+
+    public function __construct(
+        public Group $group,
+        public GroupMember $member,
+        public array $alerts,
+    ) {
+    }
+
+    public function build(): self
+    {
+        $count = count($this->alerts);
+        $unsubscribeUrl = URL::signedRoute('groupe.notifications.unsubscribe', [
+            'member' => $this->member->id,
+            'type' => 'digest',
+        ]);
+
+        return $this->subject("[KLASSCI] Récapitulatif quotidien — {$count} alerte" . ($count > 1 ? 's' : ''))
+            ->view('emails.group.daily-digest')
+            ->with([
+                'group' => $this->group,
+                'member' => $this->member,
+                'alerts' => $this->alerts,
+                'unsubscribeUrl' => $unsubscribeUrl,
+            ]);
+    }
+}

--- a/app/Models/GroupAlertNotificationLog.php
+++ b/app/Models/GroupAlertNotificationLog.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GroupAlertNotificationLog extends Model
+{
+    use HasFactory;
+
+    protected $table = 'group_alert_notifications_log';
+
+    protected $fillable = [
+        'group_member_id',
+        'group_id',
+        'tenant_code',
+        'alert_type',
+        'severity',
+        'fingerprint',
+        'channel',
+        'sent_at',
+    ];
+
+    protected $casts = [
+        'sent_at' => 'datetime',
+    ];
+
+    public function groupMember()
+    {
+        return $this->belongsTo(GroupMember::class);
+    }
+
+    /**
+     * Returns true when a notification with the same fingerprint has been
+     * sent to this member within the given window. Called by the dispatcher
+     * BEFORE dispatch to short-circuit duplicates.
+     */
+    public static function wasRecentlyNotified(int $groupMemberId, string $fingerprint, int $hours): bool
+    {
+        return static::query()
+            ->where('group_member_id', $groupMemberId)
+            ->where('fingerprint', $fingerprint)
+            ->where('sent_at', '>=', now()->subHours($hours))
+            ->exists();
+    }
+}

--- a/app/Models/GroupMemberNotificationPreference.php
+++ b/app/Models/GroupMemberNotificationPreference.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AlertType;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GroupMemberNotificationPreference extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'group_member_id',
+        'email_enabled',
+        'immediate_critical',
+        'daily_digest_warnings',
+        'digest_time',
+        'dedup_hours',
+        'last_digest_sent_at',
+        'disabled_alert_types',
+    ];
+
+    protected $casts = [
+        'email_enabled' => 'boolean',
+        'immediate_critical' => 'boolean',
+        'daily_digest_warnings' => 'boolean',
+        'dedup_hours' => 'integer',
+        'last_digest_sent_at' => 'datetime',
+        'disabled_alert_types' => 'array',
+    ];
+
+    public function groupMember()
+    {
+        return $this->belongsTo(GroupMember::class);
+    }
+
+    /**
+     * Lazy getter used by AlertNotificationDispatcher — creates the row with
+     * defaults on first access so members get sensible out-of-box behavior
+     * without a seeder or UI prerequisite. Defaults are duplicated here (vs
+     * relying on the migration column defaults) so the in-memory model
+     * returned post-insert already has them populated — Eloquent doesn't
+     * refetch after firstOrCreate.
+     */
+    public static function forMember(GroupMember $member): self
+    {
+        return static::firstOrCreate(
+            ['group_member_id' => $member->id],
+            [
+                'email_enabled' => true,
+                'immediate_critical' => true,
+                'daily_digest_warnings' => true,
+                'digest_time' => '08:00',
+                'dedup_hours' => 24,
+            ],
+        );
+    }
+
+    /**
+     * True when the member has opted in for emails AND this specific
+     * AlertType isn't in their disabled list.
+     */
+    public function acceptsAlertType(AlertType|string $type): bool
+    {
+        if (! $this->email_enabled) {
+            return false;
+        }
+
+        $value = $type instanceof AlertType ? $type->value : (string) $type;
+        $disabled = (array) ($this->disabled_alert_types ?? []);
+
+        return ! in_array($value, $disabled, true);
+    }
+}

--- a/app/Services/Group/AlertFingerprintGenerator.php
+++ b/app/Services/Group/AlertFingerprintGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Group;
+
+/**
+ * Deterministic fingerprint per alert, used by the dedup layer to avoid
+ * spamming the same alert to the same recipient within a time window.
+ *
+ * `severity` is intentionally part of the key: a quota alert escalating from
+ * Warning (90%) to Critical (100%) crosses fingerprints and re-notifies —
+ * which is what the founder wants, the situation genuinely worsened.
+ */
+class AlertFingerprintGenerator
+{
+    /**
+     * @param  array{tenant_code?: string, type: string, severity: string}  $alert
+     */
+    public function generate(int $groupId, array $alert): string
+    {
+        $payload = implode('|', [
+            $groupId,
+            $alert['tenant_code'] ?? '',
+            $alert['type'] ?? '',
+            $alert['severity'] ?? '',
+        ]);
+
+        return hash('sha256', $payload);
+    }
+}

--- a/app/Services/Group/AlertNotificationDispatcher.php
+++ b/app/Services/Group/AlertNotificationDispatcher.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace App\Services\Group;
+
+use App\Enums\AlertSeverity;
+use App\Mail\Group\CriticalAlertMail;
+use App\Mail\Group\DailyAlertDigestMail;
+use App\Models\Group;
+use App\Models\GroupAlertNotificationLog;
+use App\Models\GroupMember;
+use App\Models\GroupMemberNotificationPreference;
+use App\Services\TenantAggregationService;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Core of the founder email-notifications pipeline. Orchestrates:
+ *
+ *   1. Fetch current alerts for a group (via cached getGroupHealthMetrics)
+ *   2. For each active member: filter by preferences + role matrix
+ *   3. Per-alert dedup via fingerprint + sent_at window
+ *   4. Immediate dispatch of Critical severity — digest-buffer the rest
+ *   5. Log every dispatch (or skip reason) for audit + future retry
+ *
+ * Separated from `TenantAggregationService` on purpose — the service
+ * computes alerts, the dispatcher decides who hears about them. No overlap,
+ * no cross-cutting concerns.
+ */
+class AlertNotificationDispatcher
+{
+    public function __construct(
+        protected TenantAggregationService $aggregationService,
+        protected AlertFingerprintGenerator $fingerprints,
+        protected AlertRoleMatcher $roleMatcher,
+    ) {
+    }
+
+    /**
+     * Run the immediate-critical pass for a group — dispatches individual
+     * `CriticalAlertMail` for every (member, alert) pair that passes all
+     * filters. Warnings and Info severity alerts are left for the digest
+     * runner (SendGroupAlertDigests command).
+     *
+     * Returns the count of actual mails dispatched (post-dedup).
+     */
+    public function dispatchImmediateForGroup(Group $group): int
+    {
+        if (! config('group_portal.notifications_enabled', false)) {
+            return 0;
+        }
+
+        $health = $this->aggregationService->getGroupHealthMetrics($group);
+        $alerts = collect($health['alerts'] ?? [])
+            ->filter(fn ($alert) => ($alert['severity'] ?? '') === AlertSeverity::Critical->value)
+            ->values()
+            ->all();
+
+        if (empty($alerts)) {
+            return 0;
+        }
+
+        $members = $group->members()->where('is_active', true)->get();
+        $sentCount = 0;
+
+        foreach ($members as $member) {
+            $prefs = GroupMemberNotificationPreference::forMember($member);
+
+            if (! $prefs->email_enabled || ! $prefs->immediate_critical) {
+                continue;
+            }
+            if (empty($member->email)) {
+                continue;
+            }
+
+            foreach ($alerts as $alert) {
+                if (! $this->memberAcceptsAlert($member, $prefs, $alert)) {
+                    continue;
+                }
+
+                $fingerprint = $this->fingerprints->generate($group->id, $alert);
+                if (GroupAlertNotificationLog::wasRecentlyNotified($member->id, $fingerprint, $prefs->dedup_hours)) {
+                    continue;
+                }
+
+                try {
+                    Mail::to($member->email)->send(new CriticalAlertMail($group, $member, $alert));
+                    $this->logDispatch($group, $member, $alert, $fingerprint, 'immediate');
+                    $sentCount++;
+                } catch (\Throwable $e) {
+                    Log::error('[group-notifications] immediate dispatch failed', [
+                        'group' => $group->code,
+                        'member' => $member->email,
+                        'alert_type' => $alert['type'] ?? 'unknown',
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        return $sentCount;
+    }
+
+    /**
+     * Runs the digest pass — one email per member summarising all Warning
+     * alerts they haven't already been notified about. Respects
+     * `digest_time` by sending only when the current time is within the
+     * member's configured slot AND `last_digest_sent_at` is more than 20h
+     * ago (avoids sending two digests in one day if the runner fires
+     * every 30 min).
+     */
+    public function dispatchDigestForGroup(Group $group): int
+    {
+        if (! config('group_portal.notifications_enabled', false)) {
+            return 0;
+        }
+
+        $health = $this->aggregationService->getGroupHealthMetrics($group);
+        $allAlerts = $health['alerts'] ?? [];
+        $warningAlerts = array_values(array_filter(
+            $allAlerts,
+            fn ($alert) => ($alert['severity'] ?? '') === AlertSeverity::Warning->value
+        ));
+
+        if (empty($warningAlerts)) {
+            return 0;
+        }
+
+        $members = $group->members()->where('is_active', true)->get();
+        $sentCount = 0;
+
+        foreach ($members as $member) {
+            $prefs = GroupMemberNotificationPreference::forMember($member);
+
+            if (! $prefs->email_enabled || ! $prefs->daily_digest_warnings) {
+                continue;
+            }
+            if (empty($member->email)) {
+                continue;
+            }
+            if (! $this->isWithinDigestSlot($prefs)) {
+                continue;
+            }
+
+            // Filter alerts by member's opt-outs and role matrix
+            $deliverables = [];
+            foreach ($warningAlerts as $alert) {
+                if (! $this->memberAcceptsAlert($member, $prefs, $alert)) {
+                    continue;
+                }
+
+                $fingerprint = $this->fingerprints->generate($group->id, $alert);
+                if (GroupAlertNotificationLog::wasRecentlyNotified($member->id, $fingerprint, $prefs->dedup_hours)) {
+                    continue;
+                }
+
+                $deliverables[] = ['alert' => $alert, 'fingerprint' => $fingerprint];
+            }
+
+            if (empty($deliverables)) {
+                continue;
+            }
+
+            try {
+                $alertsForMail = array_column($deliverables, 'alert');
+                Mail::to($member->email)->send(new DailyAlertDigestMail($group, $member, $alertsForMail));
+
+                foreach ($deliverables as $d) {
+                    $this->logDispatch($group, $member, $d['alert'], $d['fingerprint'], 'digest');
+                }
+
+                $prefs->update(['last_digest_sent_at' => now()]);
+                $sentCount++;
+            } catch (\Throwable $e) {
+                Log::error('[group-notifications] digest dispatch failed', [
+                    'group' => $group->code,
+                    'member' => $member->email,
+                    'alert_count' => count($deliverables),
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $sentCount;
+    }
+
+    private function memberAcceptsAlert(GroupMember $member, GroupMemberNotificationPreference $prefs, array $alert): bool
+    {
+        $type = $alert['type'] ?? null;
+        if ($type === null || ! $prefs->acceptsAlertType($type)) {
+            return false;
+        }
+
+        return $this->roleMatcher->isSubscribedByValue($member->role, $type);
+    }
+
+    private function isWithinDigestSlot(GroupMemberNotificationPreference $prefs): bool
+    {
+        // Only send if we're in the configured HH window AND the last digest
+        // was >20h ago (or never). Matches a "once per day" invariant.
+        $digestHour = (int) substr($prefs->digest_time, 0, 2);
+        $currentHour = now()->hour;
+
+        if ($currentHour !== $digestHour) {
+            return false;
+        }
+
+        if ($prefs->last_digest_sent_at !== null
+            && $prefs->last_digest_sent_at->greaterThan(now()->subHours(20))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function logDispatch(Group $group, GroupMember $member, array $alert, string $fingerprint, string $channel): void
+    {
+        GroupAlertNotificationLog::create([
+            'group_member_id' => $member->id,
+            'group_id' => $group->id,
+            'tenant_code' => $alert['tenant_code'] ?? null,
+            'alert_type' => $alert['type'] ?? 'unknown',
+            'severity' => $alert['severity'] ?? 'info',
+            'fingerprint' => $fingerprint,
+            'channel' => $channel,
+            'sent_at' => now(),
+        ]);
+    }
+}

--- a/app/Services/Group/AlertRoleMatcher.php
+++ b/app/Services/Group/AlertRoleMatcher.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\Group;
+
+use App\Enums\AlertType;
+
+/**
+ * Decides whether a given `GroupMember` role should receive a specific
+ * `AlertType`. Strategy pattern — the matrix is data, not conditionals
+ * scattered through the dispatcher.
+ *
+ * Defaults: `fondateur` and `directeur_general` get everything (full
+ * operational oversight). `directeur_financier` gets only alerts that
+ * directly affect cash — subscription expiry, unpaid invoices, reliquats,
+ * quota issues that block billing. SSL / stale tenant / teacher workload
+ * are ops signals, noise for a CFO.
+ */
+class AlertRoleMatcher
+{
+    private const FINANCIAL_ROLE_ALERTS = [
+        AlertType::SubscriptionExpired,
+        AlertType::SubscriptionExpiring,
+        AlertType::QuotaExceeded,
+        AlertType::QuotaCritical,
+        AlertType::PlanMismatch,
+        AlertType::ActiveReliquats,
+        AlertType::UnpaidInvoices,
+    ];
+
+    public function isSubscribed(string $role, AlertType $type): bool
+    {
+        return match ($role) {
+            'fondateur', 'directeur_general' => true,
+            'directeur_financier' => in_array($type, self::FINANCIAL_ROLE_ALERTS, true),
+            default => false,
+        };
+    }
+
+    public function isSubscribedByValue(string $role, string $typeValue): bool
+    {
+        $type = AlertType::tryFrom($typeValue);
+
+        return $type !== null && $this->isSubscribed($role, $type);
+    }
+}

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -119,4 +119,28 @@ return [
     // warning at 30h gives a 10h cushion before the hard ceiling.
     'teacher_workload_warning_hours' => env('GROUP_PORTAL_TEACHER_WORKLOAD_WARNING_HOURS', 30),
     'teacher_workload_critical_hours' => env('GROUP_PORTAL_TEACHER_WORKLOAD_CRITICAL_HOURS', 40),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Founder email notifications (PR-C)
+    |--------------------------------------------------------------------------
+    |
+    | Pushes alerts surfaced by GroupAlertsWidget directly to group member
+    | inboxes (founder, directeur_general, directeur_financier). Two channels:
+    |
+    |   immediate  — Critical severity alerts, dispatched every 15 min
+    |                (aligned with the 5-min health-metrics cache)
+    |   digest     — Warning severity, one email/day per member at their
+    |                configured digest_time slot
+    |
+    | Default OFF for safe rollout — ship with the pipeline wired but dark.
+    | Flip on per-environment via env:
+    |
+    |   GROUP_PORTAL_NOTIFICATIONS_ENABLED=true
+    |
+    | Dedup: each member's `group_alert_notifications_log` is consulted BEFORE
+    | dispatch — same fingerprint (group+tenant+type+severity) within the
+    | member's dedup_hours window is skipped silently.
+    */
+    'notifications_enabled' => env('GROUP_PORTAL_NOTIFICATIONS_ENABLED', false),
 ];

--- a/database/migrations/2026_04_22_005316_create_group_member_notification_preferences_table.php
+++ b/database/migrations/2026_04_22_005316_create_group_member_notification_preferences_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Preferences per `GroupMember` — one row per member (unique constraint).
+     * Row is auto-created with defaults on first read so the UI never needs a
+     * "enable notifications" onboarding step; opt-out is explicit.
+     */
+    public function up(): void
+    {
+        Schema::create('group_member_notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('group_member_id')
+                ->constrained('group_members')
+                ->cascadeOnDelete();
+
+            $table->boolean('email_enabled')->default(true);
+            $table->boolean('immediate_critical')->default(true);
+            $table->boolean('daily_digest_warnings')->default(true);
+
+            // HH:MM in the app timezone — Africa/Abidjan per config/app.php.
+            $table->string('digest_time', 5)->default('08:00');
+
+            // Minimum time between two sends of the same fingerprint. 24h
+            // matches the existing GroupAlertCheck::checkGroup dedup window.
+            $table->unsignedSmallInteger('dedup_hours')->default(24);
+
+            $table->timestamp('last_digest_sent_at')->nullable();
+
+            // JSON list of AlertType::value strings the member has opted out
+            // of. Kept as JSON (not columns) so adding new alert types in the
+            // enum doesn't require a migration here.
+            $table->json('disabled_alert_types')->nullable();
+
+            $table->timestamps();
+
+            $table->unique('group_member_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_member_notification_preferences');
+    }
+};

--- a/database/migrations/2026_04_22_005317_create_group_alert_notifications_log_table.php
+++ b/database/migrations/2026_04_22_005317_create_group_alert_notifications_log_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Append-only log of every email dispatched by the group notification
+     * pipeline. Serves two purposes:
+     *   - Dedup: before sending, check last row per (member, fingerprint) and
+     *     skip if within `dedup_hours`.
+     *   - Audit: ops can answer "was the founder notified when tenant X
+     *     expired?" without grepping mail server logs.
+     *
+     * Retention is a future concern (30-90 days via cleanup command); the
+     * index on (group_member_id, fingerprint, sent_at) keeps lookups fast
+     * until then.
+     */
+    public function up(): void
+    {
+        Schema::create('group_alert_notifications_log', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('group_member_id')
+                ->constrained('group_members')
+                ->cascadeOnDelete();
+
+            // group_id copied from the member row so dashboards don't need
+            // to join group_members just to get the parent group.
+            $table->unsignedBigInteger('group_id')->index();
+
+            // Null for group-level alerts that don't target a single tenant.
+            $table->string('tenant_code', 50)->nullable()->index();
+
+            $table->string('alert_type', 40);
+            $table->string('severity', 20);
+
+            // sha256({group_id, tenant_code, alert_type, severity}) — severity
+            // deliberately included so "quota 91% Warning" and "quota 101%
+            // Critical" cross into different fingerprints and re-notify.
+            $table->string('fingerprint', 64);
+
+            $table->enum('channel', ['immediate', 'digest']);
+
+            $table->timestamp('sent_at');
+            $table->timestamps();
+
+            $table->index(['group_member_id', 'fingerprint', 'sent_at'], 'ganl_dedup_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_alert_notifications_log');
+    }
+};

--- a/resources/views/emails/group/critical-alert.blade.php
+++ b/resources/views/emails/group/critical-alert.blade.php
@@ -1,0 +1,27 @@
+@component('emails.group.layout', [
+    'group' => $group,
+    'unsubscribeUrl' => $unsubscribeUrl,
+    'title' => 'Alerte critique KLASSCI',
+    'headerTitle' => 'Alerte critique détectée',
+])
+    <p>Bonjour {{ $member->name }},</p>
+
+    <p>Une alerte critique a été détectée sur votre groupe <strong>{{ $group->name }}</strong>.
+    Une action immédiate peut être nécessaire pour éviter une interruption de service.</p>
+
+    <div class="alert-card alert-critical">
+        <p class="alert-title">{{ $alert['message'] }}</p>
+        <p class="alert-tenant">
+            Établissement : <strong>{{ $alert['tenant_name'] ?? $alert['tenant_code'] ?? '—' }}</strong>
+        </p>
+    </div>
+
+    <p>
+        <a href="{{ url('/groupe/alertes') }}" class="cta">Voir toutes les alertes</a>
+    </p>
+
+    <p style="color: #64748b; font-size: 0.82rem; margin-top: 20px;">
+        Cette alerte a été envoyée parce qu'elle dépasse les seuils critiques configurés pour
+        votre groupe. Vous pouvez ajuster vos préférences de notification depuis le portail.
+    </p>
+@endcomponent

--- a/resources/views/emails/group/daily-digest.blade.php
+++ b/resources/views/emails/group/daily-digest.blade.php
@@ -1,0 +1,30 @@
+@component('emails.group.layout', [
+    'group' => $group,
+    'unsubscribeUrl' => $unsubscribeUrl,
+    'title' => 'Récapitulatif quotidien KLASSCI',
+    'headerTitle' => 'Récapitulatif du jour',
+])
+    <p>Bonjour {{ $member->name }},</p>
+
+    <p>Voici le récapitulatif des alertes de niveau <strong>avertissement</strong> détectées
+    aujourd'hui sur votre groupe <strong>{{ $group->name }}</strong>.</p>
+
+    @foreach ($alerts as $alert)
+        <div class="alert-card alert-warning">
+            <p class="alert-title">{{ $alert['message'] }}</p>
+            <p class="alert-tenant">
+                Établissement : <strong>{{ $alert['tenant_name'] ?? $alert['tenant_code'] ?? '—' }}</strong>
+            </p>
+        </div>
+    @endforeach
+
+    <p>
+        <a href="{{ url('/groupe/alertes') }}" class="cta">Ouvrir le portail groupe</a>
+    </p>
+
+    <p style="color: #64748b; font-size: 0.82rem; margin-top: 20px;">
+        Les alertes critiques vous sont envoyées individuellement et immédiatement ; ce
+        récapitulatif regroupe les avertissements moins urgents pour éviter de saturer votre
+        boîte de réception.
+    </p>
+@endcomponent

--- a/resources/views/emails/group/layout.blade.php
+++ b/resources/views/emails/group/layout.blade.php
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $title ?? 'KLASSCI — Alertes' }}</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #f2f2f2;
+            font-family: Arial, sans-serif;
+            color: #1e293b;
+        }
+        .container {
+            max-width: 640px;
+            margin: 24px auto;
+            background: #ffffff;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+        }
+        .header {
+            background: #0453cb;
+            padding: 28px 32px;
+            color: #ffffff;
+        }
+        .header-brand {
+            font-size: 0.82rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            opacity: 0.85;
+            margin-bottom: 6px;
+        }
+        .header-title {
+            font-size: 1.3rem;
+            font-weight: 700;
+            margin: 0;
+        }
+        .content {
+            padding: 28px 32px;
+        }
+        .content p {
+            line-height: 1.55;
+            margin: 0 0 14px;
+        }
+        .alert-card {
+            background: #f8fafc;
+            border-left: 4px solid #0453cb;
+            border-radius: 6px;
+            padding: 16px 18px;
+            margin: 18px 0;
+        }
+        .alert-card.alert-critical {
+            border-left-color: #dc2626;
+            background: #fef2f2;
+        }
+        .alert-card.alert-warning {
+            border-left-color: #d97706;
+            background: #fffbeb;
+        }
+        .alert-title {
+            font-weight: 700;
+            margin: 0 0 4px;
+            color: #0f172a;
+        }
+        .alert-tenant {
+            font-size: 0.82rem;
+            color: #64748b;
+            margin: 4px 0 0;
+        }
+        .cta {
+            display: inline-block;
+            margin-top: 16px;
+            padding: 12px 22px;
+            background: #ffffff;
+            color: #0453cb !important;
+            border: 2px solid #0453cb;
+            border-radius: 8px;
+            text-decoration: none;
+            font-weight: 700;
+        }
+        .footer {
+            background: #f8fafc;
+            padding: 18px 32px;
+            border-top: 3px solid #0453cb;
+            font-size: 0.78rem;
+            color: #64748b;
+        }
+        .footer a {
+            color: #0453cb;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="header-brand">KLASSCI — Portail groupe</div>
+            <h1 class="header-title">{{ $headerTitle ?? 'Alertes de votre groupe' }}</h1>
+        </div>
+
+        <div class="content">
+            {{ $slot }}
+        </div>
+
+        <div class="footer">
+            Vous recevez cet email parce que vous êtes membre du groupe <strong>{{ $group->name }}</strong>.<br>
+            Pour gérer vos préférences ou vous désabonner de ce type d'alerte,
+            <a href="{{ $unsubscribeUrl }}">cliquez ici</a>.
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/emails/group/unsubscribed.blade.php
+++ b/resources/views/emails/group/unsubscribed.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KLASSCI — Préférences de notification</title>
+    <style>
+        body { margin: 0; padding: 40px 20px; background: #f2f2f2; font-family: Arial, sans-serif; color: #1e293b; }
+        .card { max-width: 520px; margin: 0 auto; background: #ffffff; border-radius: 12px; padding: 40px; box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08); text-align: center; }
+        .check { font-size: 3rem; color: #10b981; margin-bottom: 12px; }
+        h1 { color: #0f172a; margin: 0 0 12px; font-size: 1.4rem; }
+        p { color: #475569; line-height: 1.55; }
+        a { color: #0453cb; text-decoration: none; font-weight: 600; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="check">✓</div>
+        <h1>Préférence mise à jour</h1>
+        <p>Bonjour {{ $member->name }},</p>
+        @if ($type === 'digest')
+            <p>Vous ne recevrez plus le récapitulatif quotidien des avertissements.</p>
+        @else
+            <p>Vous ne recevrez plus d'emails pour ce type d'alerte.</p>
+        @endif
+        <p>Pour modifier à nouveau vos préférences, connectez-vous au <a href="{{ url('/groupe') }}">portail groupe</a>.</p>
+    </div>
+</body>
+</html>

--- a/routes/console.php
+++ b/routes/console.php
@@ -122,3 +122,36 @@ scheduleWithTimestamp(
     storage_path('logs/rotate-logs.log'),
     'tenant:rotate-logs --days=30'
 );
+
+// ============================================
+// Group portal email notifications (PR-C)
+// ============================================
+
+// Immediate critical alerts — every 15 min (alerts already cached 5 min,
+// so this means up to 20 min lag end-to-end). Skipped entirely when the
+// feature flag is off.
+scheduleWithTimestamp(
+    Schedule::command('group:dispatch-alert-notifications')
+        ->everyFifteenMinutes()
+        ->withoutOverlapping()
+        ->runInBackground()
+        ->skip(fn () => ! config('group_portal.notifications_enabled', false))
+        ->onSuccess(fn () => \Log::info('✅ Group immediate alerts dispatched'))
+        ->onFailure(fn () => \Log::error('❌ Group immediate alerts dispatch failed')),
+    storage_path('logs/group-notifications.log'),
+    'group:dispatch-alert-notifications'
+);
+
+// Digest sweep — every 30 min the dispatcher checks each member's
+// digest_time slot; actual send happens once per day when the slot matches.
+scheduleWithTimestamp(
+    Schedule::command('group:send-alert-digests')
+        ->everyThirtyMinutes()
+        ->withoutOverlapping()
+        ->runInBackground()
+        ->skip(fn () => ! config('group_portal.notifications_enabled', false))
+        ->onSuccess(fn () => \Log::info('✅ Group digests dispatched'))
+        ->onFailure(fn () => \Log::error('❌ Group digests dispatch failed')),
+    storage_path('logs/group-digests.log'),
+    'group:send-alert-digests'
+);

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,3 +53,32 @@ Route::middleware(['web', 'auth:group', 'throttle:30,1'])
         return back();
     })
     ->name('groupe.alerts.unacknowledge');
+
+// Signed unsubscribe link included in every notification email — adds the
+// alert type to the member's `disabled_alert_types` so future notifications
+// of that type are skipped by AlertNotificationDispatcher. No auth: the
+// signature itself proves identity (signed route with member id in URL).
+Route::middleware(['web', 'signed'])
+    ->get('/groupe/notifications/desabonner/{member}/{type}', function (int $member, string $type) {
+        $memberModel = \App\Models\GroupMember::findOrFail($member);
+        $prefs = \App\Models\GroupMemberNotificationPreference::forMember($memberModel);
+
+        if ($type === 'digest') {
+            $prefs->update(['daily_digest_warnings' => false]);
+        } elseif (\App\Enums\AlertType::tryFrom($type) !== null) {
+            $disabled = (array) ($prefs->disabled_alert_types ?? []);
+            if (! in_array($type, $disabled, true)) {
+                $disabled[] = $type;
+                $prefs->update(['disabled_alert_types' => array_values($disabled)]);
+            }
+        } else {
+            // Generic opt-out — kill email entirely
+            $prefs->update(['email_enabled' => false]);
+        }
+
+        return response()->view('emails.group.unsubscribed', [
+            'member' => $memberModel,
+            'type' => $type,
+        ]);
+    })
+    ->name('groupe.notifications.unsubscribe');

--- a/tests/Feature/Group/AlertNotificationDispatcherTest.php
+++ b/tests/Feature/Group/AlertNotificationDispatcherTest.php
@@ -1,0 +1,213 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupAlertNotificationLog;
+use App\Models\GroupMember;
+use App\Models\GroupMemberNotificationPreference;
+use App\Services\Group\AlertFingerprintGenerator;
+use App\Services\Group\AlertNotificationDispatcher;
+use App\Services\Group\AlertRoleMatcher;
+use App\Services\TenantAggregationService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    config()->set('group_portal.notifications_enabled', true);
+    config()->set('mail.default', 'array');      // in-memory mailer
+    config()->set('queue.default', 'sync');      // ShouldQueue mailables run inline
+
+    $this->group = Group::create(['name' => 'Test Group', 'code' => 'test', 'status' => 'active']);
+    $this->member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'Test Fondateur',
+        'email' => 'fondateur@test.fr',
+        'password' => bcrypt('secret'),
+        'role' => 'fondateur',
+        'is_active' => true,
+    ]);
+});
+
+/**
+ * Anonymous class stub — avoids Mockery (not installed) for the narrow
+ * need of overriding one method's return value.
+ */
+function stubAggregation(array $alerts): TenantAggregationService
+{
+    return new class($alerts) extends TenantAggregationService {
+        public function __construct(private array $alertsToReturn)
+        {
+            // Parent constructor deliberately not called — only getGroupHealthMetrics
+            // is exercised by the dispatcher's code path.
+        }
+
+        public function getGroupHealthMetrics(\App\Models\Group $group): array
+        {
+            return ['alerts' => $this->alertsToReturn];
+        }
+    };
+}
+
+function makeDispatcher(TenantAggregationService $aggregation): AlertNotificationDispatcher
+{
+    return new AlertNotificationDispatcher(
+        $aggregation,
+        new AlertFingerprintGenerator(),
+        new AlertRoleMatcher(),
+    );
+}
+
+it('dispatches immediate mail for a Critical alert to a fondateur', function () {
+    $alerts = [[
+        'severity' => 'critical',
+        'tenant_code' => 'rostan',
+        'tenant_name' => 'ROSTAN',
+        'type' => 'subscription_expired',
+        'message' => 'Abonnement expiré',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(1);
+
+    // Log row written for future dedup
+    expect(GroupAlertNotificationLog::count())->toBe(1);
+    $log = GroupAlertNotificationLog::first();
+    expect($log->channel)->toBe('immediate');
+    expect($log->alert_type)->toBe('subscription_expired');
+    expect($log->severity)->toBe('critical');
+});
+
+it('skips Warning severity on the immediate pass (those go to the digest)', function () {
+    $alerts = [[
+        'severity' => 'warning',
+        'tenant_code' => 'rostan',
+        'tenant_name' => 'ROSTAN',
+        'type' => 'plan_mismatch',
+        'message' => 'Plan dépassé',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(0);
+    expect(GroupAlertNotificationLog::count())->toBe(0);
+});
+
+it('honours the kill switch — sends nothing when notifications_enabled is false', function () {
+    config()->set('group_portal.notifications_enabled', false);
+
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'subscription_expired', 'message' => 'Expired',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(0);
+    expect(GroupAlertNotificationLog::count())->toBe(0);
+});
+
+it('dedups — same fingerprint within the window is not re-sent', function () {
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'subscription_expired', 'message' => 'Expired',
+    ]];
+
+    $dispatcher = makeDispatcher(stubAggregation($alerts));
+
+    $first = $dispatcher->dispatchImmediateForGroup($this->group);
+    $second = $dispatcher->dispatchImmediateForGroup($this->group);
+
+    expect($first)->toBe(1);
+    expect($second)->toBe(0);  // deduped
+    expect(GroupAlertNotificationLog::count())->toBe(1);  // only one log row
+});
+
+it('respects the member opt-out for a specific AlertType', function () {
+    GroupMemberNotificationPreference::forMember($this->member)->update([
+        'disabled_alert_types' => ['subscription_expired'],
+    ]);
+
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'subscription_expired', 'message' => 'Expired',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(0);
+    expect(GroupAlertNotificationLog::count())->toBe(0);
+});
+
+it('filters by role matrix — directeur_financier skips ops alerts', function () {
+    $this->member->update(['role' => 'directeur_financier']);
+
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'ssl_expiring', 'message' => 'SSL expiring',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(0);  // SSL is an ops alert, not financial
+    expect(GroupAlertNotificationLog::count())->toBe(0);
+});
+
+it('directeur_financier DOES receive financial alerts', function () {
+    $this->member->update(['role' => 'directeur_financier']);
+
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'unpaid_invoices', 'message' => 'Factures impayées',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(1);
+    expect(GroupAlertNotificationLog::count())->toBe(1);
+});
+
+it('skips members without an email address', function () {
+    $this->member->update(['email' => '']);
+
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'subscription_expired', 'message' => 'Expired',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(0);
+    expect(GroupAlertNotificationLog::count())->toBe(0);
+});
+
+it('skips inactive members', function () {
+    $this->member->update(['is_active' => false]);
+
+    $alerts = [[
+        'severity' => 'critical', 'tenant_code' => 'rostan', 'tenant_name' => 'ROSTAN',
+        'type' => 'subscription_expired', 'message' => 'Expired',
+    ]];
+
+    $sent = makeDispatcher(stubAggregation($alerts))->dispatchImmediateForGroup($this->group);
+
+    expect($sent)->toBe(0);
+    expect(GroupAlertNotificationLog::count())->toBe(0);
+});
+
+it('GroupAlertNotificationLog::wasRecentlyNotified returns true inside the window', function () {
+    GroupAlertNotificationLog::create([
+        'group_member_id' => $this->member->id,
+        'group_id' => $this->group->id,
+        'tenant_code' => 'rostan',
+        'alert_type' => 'subscription_expired',
+        'severity' => 'critical',
+        'fingerprint' => 'abc123',
+        'channel' => 'immediate',
+        'sent_at' => now()->subHours(2),
+    ]);
+
+    expect(GroupAlertNotificationLog::wasRecentlyNotified($this->member->id, 'abc123', 24))->toBeTrue();
+    expect(GroupAlertNotificationLog::wasRecentlyNotified($this->member->id, 'abc123', 1))->toBeFalse();
+});

--- a/tests/Unit/Services/Group/AlertFingerprintGeneratorTest.php
+++ b/tests/Unit/Services/Group/AlertFingerprintGeneratorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Services\Group\AlertFingerprintGenerator;
+
+it('generates the same fingerprint for the same (group, tenant, type, severity) tuple', function () {
+    $generator = new AlertFingerprintGenerator();
+
+    $alert = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+
+    $fp1 = $generator->generate(1, $alert);
+    $fp2 = $generator->generate(1, $alert);
+
+    expect($fp1)->toBe($fp2);
+    expect($fp1)->toBe(hash('sha256', '1|rostan|ssl_expiring|critical'));
+});
+
+it('changes fingerprint when severity escalates (so re-notify fires)', function () {
+    $generator = new AlertFingerprintGenerator();
+
+    $warning = ['tenant_code' => 'rostan', 'type' => 'quota_critical', 'severity' => 'warning'];
+    $critical = ['tenant_code' => 'rostan', 'type' => 'quota_critical', 'severity' => 'critical'];
+
+    expect($generator->generate(1, $warning))->not->toBe($generator->generate(1, $critical));
+});
+
+it('changes fingerprint when tenant differs (per-tenant dedup)', function () {
+    $generator = new AlertFingerprintGenerator();
+
+    $tenantA = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+    $tenantB = ['tenant_code' => 'yakro', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+
+    expect($generator->generate(1, $tenantA))->not->toBe($generator->generate(1, $tenantB));
+});
+
+it('changes fingerprint when group differs (cross-group isolation)', function () {
+    $generator = new AlertFingerprintGenerator();
+
+    $alert = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+
+    expect($generator->generate(1, $alert))->not->toBe($generator->generate(2, $alert));
+});
+
+it('handles missing keys without throwing (defensive against upstream drift)', function () {
+    $generator = new AlertFingerprintGenerator();
+
+    $degraded = ['severity' => 'warning'];  // no tenant_code, no type
+
+    $fp = $generator->generate(1, $degraded);
+    expect($fp)->toBeString();
+    expect(strlen($fp))->toBe(64);  // sha256 hex
+});

--- a/tests/Unit/Services/Group/AlertRoleMatcherTest.php
+++ b/tests/Unit/Services/Group/AlertRoleMatcherTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\AlertType;
+use App\Services\Group\AlertRoleMatcher;
+
+it('fondateur receives every alert type', function () {
+    $matcher = new AlertRoleMatcher();
+
+    foreach (AlertType::cases() as $type) {
+        expect($matcher->isSubscribed('fondateur', $type))->toBeTrue();
+    }
+});
+
+it('directeur_general receives every alert type (full operational oversight)', function () {
+    $matcher = new AlertRoleMatcher();
+
+    foreach (AlertType::cases() as $type) {
+        expect($matcher->isSubscribed('directeur_general', $type))->toBeTrue();
+    }
+});
+
+it('directeur_financier receives financial alerts only', function () {
+    $matcher = new AlertRoleMatcher();
+
+    // Accepted:
+    expect($matcher->isSubscribed('directeur_financier', AlertType::SubscriptionExpired))->toBeTrue();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::UnpaidInvoices))->toBeTrue();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::PlanMismatch))->toBeTrue();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::QuotaExceeded))->toBeTrue();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::ActiveReliquats))->toBeTrue();
+
+    // Rejected (ops signals, CFO doesn't need them):
+    expect($matcher->isSubscribed('directeur_financier', AlertType::SslExpiring))->toBeFalse();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::StaleTenant))->toBeFalse();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::TeacherOverload))->toBeFalse();
+    expect($matcher->isSubscribed('directeur_financier', AlertType::HighAttrition))->toBeFalse();
+});
+
+it('unknown roles receive nothing (default-deny)', function () {
+    $matcher = new AlertRoleMatcher();
+
+    expect($matcher->isSubscribed('unknown_role', AlertType::SubscriptionExpired))->toBeFalse();
+    expect($matcher->isSubscribed('', AlertType::UnpaidInvoices))->toBeFalse();
+});
+
+it('isSubscribedByValue handles invalid AlertType strings gracefully', function () {
+    $matcher = new AlertRoleMatcher();
+
+    expect($matcher->isSubscribedByValue('fondateur', 'not_a_real_type'))->toBeFalse();
+    expect($matcher->isSubscribedByValue('fondateur', 'subscription_expired'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Pushes alerts surfaced by \`GroupAlertsWidget\` directly to group member inboxes. Two channels:

- **immediate** — Critical severity, dispatched every 15 min (aligned with 5-min health cache)
- **digest** — Warning severity, one email/day per member at their configured digest_time

Default OFF via \`GROUP_PORTAL_NOTIFICATIONS_ENABLED=false\` — ships wired but dark.

## Architecture

- \`AlertFingerprintGenerator\` — sha256({group, tenant, type, severity}) for dedup (severity included so escalations re-notify)
- \`AlertRoleMatcher\` — fondateur + DG get everything, directeur_financier gets financial only
- \`AlertNotificationDispatcher\` — orchestrator (fetch cached alerts, filter by prefs+role+dedup, dispatch Mail, log)

## Storage

- \`group_member_notification_preferences\` — unique per member, lazy-created with defaults. JSON \`disabled_alert_types\` scales with the enum
- \`group_alert_notifications_log\` — append-only audit + dedup source, indexed on (member, fingerprint, sent_at)

## Emails

- 2 Mailables (\`ShouldQueue\`, tries=3, exponential backoff)
- 3 Blade templates (layout + critical-alert + daily-digest) + unsubscribe confirmation page
- Signed unsubscribe URL in every email → updates \`disabled_alert_types\` / kills channel

## Scheduler

- \`group:dispatch-alert-notifications\` every 15 min (skipped when flag off)
- \`group:send-alert-digests\` every 30 min (per-member digest_time slot check)

## Tests

20 new: 5 fingerprint (determinism, severity differentiation, cross-group isolation), 5 role matrix (3 roles × alert-type coverage), 10 dispatcher (critical path, kill switch, dedup, role filter, inactive/empty-email skips, log contract). 168 group tests pass, 472 assertions, 0 regression.

## Type

feat