### PR TITLE
chore(group-portal): backed enums SubscriptionTier / SslTier / StaleTier

### DIFF
--- a/app/Enums/SslTier.php
+++ b/app/Enums/SslTier.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * SSL certificate expiry tier — typed alternative to
+ * `HealthCheckAlertResolver::SSL_TIER_*` string constants. Values preserved
+ * so string-based callers keep working unchanged.
+ */
+enum SslTier: string
+{
+    case Critical = 'critical';
+    case Warning = 'warning';
+
+    public function severity(): AlertSeverity
+    {
+        return match ($this) {
+            self::Critical => AlertSeverity::Critical,
+            self::Warning => AlertSeverity::Warning,
+        };
+    }
+}

--- a/app/Enums/StaleTier.php
+++ b/app/Enums/StaleTier.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Tenant staleness tier — typed alternative to
+ * `HealthCheckAlertResolver::STALE_TIER_*` string constants. Values preserved
+ * so string-based callers keep working unchanged.
+ *
+ * `Unhealthy` (latest health check failed) always supersedes `Stale` (deploy
+ * age) so the UI surfaces a single alert per tenant — precedence is enforced
+ * in `HealthCheckAlertResolver::resolveStaleTier()`, not at the enum level.
+ */
+enum StaleTier: string
+{
+    case Unhealthy = 'unhealthy';
+    case Stale = 'stale';
+
+    public function severity(): AlertSeverity
+    {
+        return match ($this) {
+            self::Unhealthy => AlertSeverity::Critical,
+            self::Stale => AlertSeverity::Warning,
+        };
+    }
+}

--- a/app/Enums/SubscriptionTier.php
+++ b/app/Enums/SubscriptionTier.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Subscription expiry tier — strictly-typed alternative to the string
+ * constants on `SubscriptionTierResolver`. Values are identical to
+ * `SubscriptionTierResolver::TIER_*` so cached `$health['subscription_worst_tier']`
+ * strings still match when callers do `->value` comparison.
+ *
+ * The constants on the resolver class remain in place as string aliases —
+ * Blade `match` expressions against cached tier strings would crash with
+ * `UnhandledMatchError` if the constants were removed (see critic audit
+ * on PR-D for the full rationale).
+ */
+enum SubscriptionTier: string
+{
+    case Expired = 'expired';
+    case Urgent = 'urgent';
+    case Warning = 'warning';
+    case Info = 'info';
+
+    /**
+     * Lower rank = more urgent — drives `worstTier()` aggregation.
+     */
+    public function rank(): int
+    {
+        return match ($this) {
+            self::Expired => 0,
+            self::Urgent => 1,
+            self::Warning => 2,
+            self::Info => 3,
+        };
+    }
+
+    public function severity(): AlertSeverity
+    {
+        return match ($this) {
+            self::Expired, self::Urgent => AlertSeverity::Critical,
+            self::Warning => AlertSeverity::Warning,
+            self::Info => AlertSeverity::Info,
+        };
+    }
+}

--- a/app/Services/Group/HealthCheckAlertResolver.php
+++ b/app/Services/Group/HealthCheckAlertResolver.php
@@ -3,6 +3,8 @@
 namespace App\Services\Group;
 
 use App\Enums\AlertSeverity;
+use App\Enums\SslTier;
+use App\Enums\StaleTier;
 use App\Models\Tenant;
 use App\Models\TenantHealthCheck;
 
@@ -18,6 +20,10 @@ use App\Models\TenantHealthCheck;
  *
  * Tiers are resolved separately so the same tenant can surface both alerts
  * (e.g. deployed 40 days ago AND SSL expiring in 5 days).
+ *
+ * String constants + backed enums coexist: `SSL_TIER_*` / `STALE_TIER_*`
+ * strings remain for legacy callers and any future cache-serialized value;
+ * new callers should prefer the `SslTier` / `StaleTier` enum variants.
  */
 class HealthCheckAlertResolver
 {
@@ -105,5 +111,24 @@ class HealthCheckAlertResolver
             self::STALE_TIER_STALE => AlertSeverity::Warning,
             default => AlertSeverity::Info,
         };
+    }
+
+    /**
+     * Typed alternatives — wrap the existing string-based methods. Callers
+     * that want exhaustive `match` / IDE safety use these; legacy callers
+     * keep the string API without any forced migration.
+     */
+    public function resolveSslTierEnum(?TenantHealthCheck $latestSslCheck): ?SslTier
+    {
+        $tier = $this->resolveSslTier($latestSslCheck);
+
+        return $tier === null ? null : SslTier::from($tier);
+    }
+
+    public function resolveStaleTierEnum(Tenant $tenant, ?TenantHealthCheck $latestCheck): ?StaleTier
+    {
+        $tier = $this->resolveStaleTier($tenant, $latestCheck);
+
+        return $tier === null ? null : StaleTier::from($tier);
     }
 }

--- a/app/Services/Group/SubscriptionTierResolver.php
+++ b/app/Services/Group/SubscriptionTierResolver.php
@@ -3,6 +3,7 @@
 namespace App\Services\Group;
 
 use App\Enums\AlertSeverity;
+use App\Enums\SubscriptionTier;
 use App\Models\Tenant;
 
 /**
@@ -10,6 +11,12 @@ use App\Models\Tenant;
  * configured in `config/group_portal.php`. Kept separate from the Tenant
  * model so it stays pure data and the resolver can be unit-tested without
  * hitting the database.
+ *
+ * String constants + enum cases live side by side intentionally:
+ * `TIER_*` strings keep backward compatibility with cached health arrays
+ * (Cache::remember on `$health['subscription_worst_tier']`) and Blade
+ * match expressions in the banner partial. New callers should prefer
+ * `resolveTierEnum()` / `SubscriptionTier` for type safety.
  */
 class SubscriptionTierResolver
 {
@@ -85,5 +92,17 @@ class SubscriptionTierResolver
             self::TIER_INFO => AlertSeverity::Info,
             default => AlertSeverity::Info,
         };
+    }
+
+    /**
+     * Typed alternative to `resolveTier()` — returns the backed enum case
+     * for callers that benefit from exhaustive `match` / IDE autocomplete.
+     * Internal implementation shares the same threshold logic.
+     */
+    public function resolveTierEnum(Tenant $tenant): ?SubscriptionTier
+    {
+        $tier = $this->resolveTier($tenant);
+
+        return $tier === null ? null : SubscriptionTier::from($tier);
     }
 }

--- a/tests/Unit/Enums/TierEnumTest.php
+++ b/tests/Unit/Enums/TierEnumTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Enums\AlertSeverity;
+use App\Enums\SslTier;
+use App\Enums\StaleTier;
+use App\Enums\SubscriptionTier;
+use App\Services\Group\HealthCheckAlertResolver;
+use App\Services\Group\SubscriptionTierResolver;
+
+/**
+ * Value-parity tests between the backed enums and the string constants on
+ * the resolver classes. The enums MUST preserve the same string values so
+ * cached `$health[...]` arrays (Cache::remember for 5 min) stay readable
+ * across deploys.
+ */
+
+it('SubscriptionTier enum values match SubscriptionTierResolver constants', function () {
+    expect(SubscriptionTier::Expired->value)->toBe(SubscriptionTierResolver::TIER_EXPIRED);
+    expect(SubscriptionTier::Urgent->value)->toBe(SubscriptionTierResolver::TIER_URGENT);
+    expect(SubscriptionTier::Warning->value)->toBe(SubscriptionTierResolver::TIER_WARNING);
+    expect(SubscriptionTier::Info->value)->toBe(SubscriptionTierResolver::TIER_INFO);
+});
+
+it('SslTier enum values match HealthCheckAlertResolver constants', function () {
+    expect(SslTier::Critical->value)->toBe(HealthCheckAlertResolver::SSL_TIER_CRITICAL);
+    expect(SslTier::Warning->value)->toBe(HealthCheckAlertResolver::SSL_TIER_WARNING);
+});
+
+it('StaleTier enum values match HealthCheckAlertResolver constants', function () {
+    expect(StaleTier::Unhealthy->value)->toBe(HealthCheckAlertResolver::STALE_TIER_UNHEALTHY);
+    expect(StaleTier::Stale->value)->toBe(HealthCheckAlertResolver::STALE_TIER_STALE);
+});
+
+it('SubscriptionTier::rank() orders expired as most urgent', function () {
+    expect(SubscriptionTier::Expired->rank())->toBeLessThan(SubscriptionTier::Urgent->rank());
+    expect(SubscriptionTier::Urgent->rank())->toBeLessThan(SubscriptionTier::Warning->rank());
+    expect(SubscriptionTier::Warning->rank())->toBeLessThan(SubscriptionTier::Info->rank());
+});
+
+it('SubscriptionTier::severity() matches the legacy severityForTier mapping', function () {
+    $resolver = new SubscriptionTierResolver();
+
+    foreach (SubscriptionTier::cases() as $tier) {
+        expect($tier->severity())->toBe($resolver->severityForTier($tier->value));
+    }
+});
+
+it('SslTier::severity() matches the legacy severityForSslTier mapping', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    foreach (SslTier::cases() as $tier) {
+        expect($tier->severity())->toBe($resolver->severityForSslTier($tier->value));
+    }
+});
+
+it('StaleTier::severity() matches the legacy severityForStaleTier mapping', function () {
+    $resolver = new HealthCheckAlertResolver();
+
+    foreach (StaleTier::cases() as $tier) {
+        expect($tier->severity())->toBe($resolver->severityForStaleTier($tier->value));
+    }
+});
+
+it('SubscriptionTier::from() round-trips legacy string values', function () {
+    // Proves that any cached tier string ever written by pre-enum code can
+    // be re-hydrated into the new enum without breakage.
+    foreach ([
+        SubscriptionTierResolver::TIER_EXPIRED,
+        SubscriptionTierResolver::TIER_URGENT,
+        SubscriptionTierResolver::TIER_WARNING,
+        SubscriptionTierResolver::TIER_INFO,
+    ] as $legacyString) {
+        $enum = SubscriptionTier::from($legacyString);
+        expect($enum->value)->toBe($legacyString);
+    }
+});


### PR DESCRIPTION
## Summary

- Adds PHP 8.1 backed enums mirroring the string constants on `SubscriptionTierResolver` + `HealthCheckAlertResolver`
- Values preserved 1:1 — cache-safe, zero breaking change
- Each resolver gets one new `resolveXxxTierEnum()` method returning the typed enum
- Legacy string API untouched so Blade `match` expressions + cached `$health` arrays keep working

## Why additive, not replacing

Cached tier strings live in `Cache::remember` under `group_v2_{id}_health_*` (TTL 300s). Blade partial `subscription-banner.blade.php` does `match($worstTier) { SubscriptionTierResolver::TIER_EXPIRED => 'danger', ... }` without a `default` arm — if we replaced the const with an enum, a deploy would crash on the first cached string that hit the partial. Keeping both side-by-side lets callers migrate progressively without the flag day.

## Tests

176 pass (+8 value-parity + round-trip), 495 assertions, 0 regression.

## Type

chore