### PR TITLE
feat(group-portal): notification preferences page

### DIFF
--- a/app/Filament/Group/Pages/NotificationPreferences.php
+++ b/app/Filament/Group/Pages/NotificationPreferences.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Filament\Group\Pages;
+
+use App\Enums\AlertType;
+use App\Filament\Group\Concerns\HasCustomHero;
+use App\Models\GroupMemberNotificationPreference;
+use Filament\Forms\Components\Grid;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+/**
+ * Self-service preferences for group-portal email notifications. A founder
+ * or director who lands in their inbox full of critical alerts doesn't want
+ * to hunt for a signed unsubscribe link in last week's email — they want a
+ * form. This page is that form.
+ */
+class NotificationPreferences extends Page implements HasForms
+{
+    use HasCustomHero;
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-bell';
+
+    protected static ?string $navigationLabel = 'Notifications';
+
+    protected static ?string $navigationGroup = 'Mon compte';
+
+    protected static ?string $title = 'Préférences de notification';
+
+    protected static ?int $navigationSort = 100;
+
+    protected static string $view = 'filament.group.pages.notification-preferences';
+
+    protected static ?string $slug = 'mes-preferences-notifications';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $prefs = $this->loadPrefs();
+
+        $this->form->fill([
+            'email_enabled' => (bool) $prefs->email_enabled,
+            'immediate_critical' => (bool) $prefs->immediate_critical,
+            'daily_digest_warnings' => (bool) $prefs->daily_digest_warnings,
+            'digest_time' => $prefs->digest_time,
+            'dedup_hours' => (int) $prefs->dedup_hours,
+            'enabled_alert_types' => $this->enabledTypesFor($prefs),
+        ]);
+    }
+
+    public function form(Form $form): Form
+    {
+        $alertTypeToggles = [];
+        foreach (AlertType::cases() as $type) {
+            $alertTypeToggles[] = Toggle::make("enabled_alert_types.{$type->value}")
+                ->label($this->labelFor($type))
+                ->helperText($this->helperFor($type))
+                ->onColor('primary')
+                ->offColor('gray');
+        }
+
+        return $form
+            ->schema([
+                Section::make('Canal principal')
+                    ->description('Interrupteur global — quand désactivé, aucun email n\'est envoyé peu importe les préférences individuelles.')
+                    ->schema([
+                        Toggle::make('email_enabled')
+                            ->label('Recevoir des emails de notification')
+                            ->onColor('primary')
+                            ->helperText('Si désactivé, les options ci-dessous sont ignorées.'),
+                    ])
+                    ->collapsible(),
+
+                Section::make('Cadence')
+                    ->description('Comment vous souhaitez recevoir les alertes.')
+                    ->schema([
+                        Grid::make(2)->schema([
+                            Toggle::make('immediate_critical')
+                                ->label('Critiques — immédiat')
+                                ->helperText('Emails individuels envoyés dès qu\'une alerte critique est détectée.'),
+
+                            Toggle::make('daily_digest_warnings')
+                                ->label('Avertissements — récapitulatif quotidien')
+                                ->helperText('Un email par jour regroupant les avertissements non critiques.'),
+                        ]),
+                        Grid::make(2)->schema([
+                            Select::make('digest_time')
+                                ->label('Heure du récapitulatif')
+                                ->options($this->digestTimeOptions())
+                                ->required()
+                                ->native(false)
+                                ->helperText('Heure d\'envoi du récapitulatif quotidien (fuseau Abidjan).'),
+
+                            Select::make('dedup_hours')
+                                ->label('Fenêtre anti-doublons')
+                                ->options([
+                                    6 => '6 heures',
+                                    12 => '12 heures',
+                                    24 => '24 heures (recommandé)',
+                                    48 => '48 heures',
+                                    72 => '72 heures',
+                                ])
+                                ->required()
+                                ->native(false)
+                                ->helperText('Délai minimum entre deux notifications pour la même alerte.'),
+                        ]),
+                    ])
+                    ->collapsible(),
+
+                Section::make('Types d\'alertes')
+                    ->description('Désactivez les types d\'alertes qui ne vous concernent pas. Chaque toggle est indépendant.')
+                    ->schema([
+                        Grid::make(2)->schema($alertTypeToggles),
+                    ])
+                    ->collapsible(),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $state = $this->form->getState();
+
+        $enabledTypes = (array) ($state['enabled_alert_types'] ?? []);
+        $disabled = [];
+        foreach (AlertType::cases() as $type) {
+            if (empty($enabledTypes[$type->value])) {
+                $disabled[] = $type->value;
+            }
+        }
+
+        $prefs = $this->loadPrefs();
+        $prefs->update([
+            'email_enabled' => (bool) ($state['email_enabled'] ?? false),
+            'immediate_critical' => (bool) ($state['immediate_critical'] ?? false),
+            'daily_digest_warnings' => (bool) ($state['daily_digest_warnings'] ?? false),
+            'digest_time' => (string) ($state['digest_time'] ?? '08:00'),
+            'dedup_hours' => (int) ($state['dedup_hours'] ?? 24),
+            'disabled_alert_types' => $disabled,
+        ]);
+
+        Notification::make()
+            ->title('Préférences enregistrées')
+            ->body('Vos préférences de notification ont été mises à jour.')
+            ->success()
+            ->send();
+    }
+
+    private function loadPrefs(): GroupMemberNotificationPreference
+    {
+        return GroupMemberNotificationPreference::forMember(auth('group')->user());
+    }
+
+    /**
+     * Inverts the `disabled_alert_types` list so the form shows each type
+     * toggled ON by default (users opt OUT, not IN — default verbose wins
+     * over silent). Returns a map of `['type_value' => bool]`.
+     */
+    private function enabledTypesFor(GroupMemberNotificationPreference $prefs): array
+    {
+        $disabled = (array) ($prefs->disabled_alert_types ?? []);
+        $enabled = [];
+
+        foreach (AlertType::cases() as $type) {
+            $enabled[$type->value] = ! in_array($type->value, $disabled, true);
+        }
+
+        return $enabled;
+    }
+
+    /**
+     * Hourly slots + a few practical mid-hour offsets. We don't need a free
+     * text input — digest arrivals are non-critical so 30-min granularity
+     * is plenty and avoids per-member timezone debugging.
+     */
+    private function digestTimeOptions(): array
+    {
+        $options = [];
+        foreach (range(6, 20) as $hour) {
+            foreach (['00', '30'] as $minute) {
+                $slot = sprintf('%02d:%s', $hour, $minute);
+                $options[$slot] = $slot;
+            }
+        }
+
+        return $options;
+    }
+
+    private function labelFor(AlertType $type): string
+    {
+        return match ($type) {
+            AlertType::QuotaExceeded => 'Quota dépassé',
+            AlertType::QuotaCritical => 'Quota critique',
+            AlertType::SubscriptionExpired => 'Abonnement expiré',
+            AlertType::SubscriptionExpiring => 'Abonnement expirant',
+            AlertType::HighAttrition => 'Attrition élevée',
+            AlertType::ActiveReliquats => 'Reliquats actifs',
+            AlertType::PlanMismatch => 'Plan dépassé',
+            AlertType::StaleTenant => 'Tenant inactif',
+            AlertType::SslExpiring => 'Certificat SSL expirant',
+            AlertType::EnrollmentDecline => 'Inscriptions en baisse',
+            AlertType::UnpaidInvoices => 'Factures impayées',
+            AlertType::TeacherOverload => 'Surcharge enseignante',
+        };
+    }
+
+    private function helperFor(AlertType $type): string
+    {
+        return match ($type) {
+            AlertType::QuotaExceeded, AlertType::QuotaCritical => 'Quotas d\'utilisateurs ou de stockage d\'un établissement.',
+            AlertType::SubscriptionExpired, AlertType::SubscriptionExpiring => 'Date d\'expiration de l\'abonnement KLASSCI.',
+            AlertType::HighAttrition => 'Taux d\'abandon d\'inscriptions élevé d\'une année à l\'autre.',
+            AlertType::ActiveReliquats => 'Restes à payer reportés d\'années antérieures.',
+            AlertType::PlanMismatch => 'Un établissement dépasse le nombre d\'étudiants prévu par son plan.',
+            AlertType::StaleTenant => 'Tenant non déployé depuis longtemps ou en échec de health check.',
+            AlertType::SslExpiring => 'Certificat SSL d\'un établissement proche de l\'expiration.',
+            AlertType::EnrollmentDecline => 'Deux mois consécutifs de baisse d\'inscriptions.',
+            AlertType::UnpaidInvoices => 'Factures émises non payées.',
+            AlertType::TeacherOverload => 'Enseignants dépassant les heures hebdomadaires maximales.',
+        };
+    }
+}

--- a/public/css/groupe-portal.css
+++ b/public/css/groupe-portal.css
@@ -1796,3 +1796,17 @@
         margin-left: auto;
     }
 }
+
+/* =========================================================================
+   Notification preferences page (PR-C follow-up)
+   ========================================================================= */
+.gp-prefs-form {
+    margin-top: 1.25rem;
+}
+.gp-prefs-actions {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid #f1f5f9;
+    display: flex;
+    justify-content: flex-end;
+}

--- a/resources/views/filament/group/pages/notification-preferences.blade.php
+++ b/resources/views/filament/group/pages/notification-preferences.blade.php
@@ -1,0 +1,22 @@
+<x-filament-panels::page>
+    <x-group-hero
+        title="Préférences de notification"
+        subtitle="Choisissez quelles alertes vous recevez, sur quel canal et à quelle fréquence"
+        icon-path="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+    >
+        <x-slot:badges>
+            <span class="gp-hero-chip">Portail groupe</span>
+            <span class="gp-hero-chip">Emails — {{ auth('group')->user()->email }}</span>
+        </x-slot:badges>
+    </x-group-hero>
+
+    <form wire:submit="save" class="gp-prefs-form">
+        {{ $this->form }}
+
+        <div class="gp-prefs-actions">
+            <x-filament::button type="submit" color="primary" size="lg">
+                Enregistrer mes préférences
+            </x-filament::button>
+        </div>
+    </form>
+</x-filament-panels::page>

--- a/tests/Feature/Group/NotificationPreferencesPageTest.php
+++ b/tests/Feature/Group/NotificationPreferencesPageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Enums\AlertType;
+use App\Filament\Group\Pages\NotificationPreferences;
+
+it('NotificationPreferences page carries the expected Filament props', function () {
+    expect(NotificationPreferences::getSlug())->toBe('mes-preferences-notifications');
+
+    $reflection = new ReflectionClass(NotificationPreferences::class);
+    expect($reflection->getStaticPropertyValue('title'))->toBe('Préférences de notification');
+    expect($reflection->getStaticPropertyValue('navigationGroup'))->toBe('Mon compte');
+});
+
+it('page implements the Filament HasForms contract', function () {
+    $class = new ReflectionClass(NotificationPreferences::class);
+
+    $interfaces = array_map(fn ($i) => $i->getName(), $class->getInterfaces());
+
+    expect($interfaces)->toContain('Filament\\Forms\\Contracts\\HasForms');
+});
+
+it('page declares every AlertType as a toggle', function () {
+    $source = file_get_contents(app_path('Filament/Group/Pages/NotificationPreferences.php'));
+
+    foreach (AlertType::cases() as $type) {
+        // Each case is referenced in labelFor() (one-line match arm per type)
+        $needle = 'AlertType::' . $type->name;
+        expect($source)->toContain($needle);
+    }
+});
+
+it('page toggles default ON so users opt OUT (verbose default)', function () {
+    $source = file_get_contents(app_path('Filament/Group/Pages/NotificationPreferences.php'));
+
+    // enabledTypesFor inverts disabled list — starting state is "every type enabled"
+    expect($source)->toContain('enabledTypesFor');
+    expect($source)->toContain('! in_array($type->value, $disabled, true)');
+});
+
+it('save() writes the inverse (disabled_alert_types) to the model', function () {
+    $source = file_get_contents(app_path('Filament/Group/Pages/NotificationPreferences.php'));
+
+    // When a type toggle is OFF, its value ends up in disabled_alert_types
+    expect($source)->toContain('$disabled[] = $type->value;');
+    expect($source)->toContain("'disabled_alert_types' => \$disabled,");
+});
+
+it('digest time options span workday hours with 30-minute granularity', function () {
+    $source = file_get_contents(app_path('Filament/Group/Pages/NotificationPreferences.php'));
+
+    expect($source)->toContain('range(6, 20)');
+    expect($source)->toContain("['00', '30']");
+});
+
+it('page lives under the Mon compte navigation group', function () {
+    $class = new ReflectionClass(NotificationPreferences::class);
+
+    expect($class->getStaticPropertyValue('navigationGroup'))->toBe('Mon compte');
+    expect($class->getStaticPropertyValue('navigationLabel'))->toBe('Notifications');
+});


### PR DESCRIPTION
## Summary

Self-service page `/groupe/mes-preferences-notifications` where members adjust their email notification preferences without the signed URL dance.

## Sections

- **Canal principal** — master `email_enabled` switch
- **Cadence** — immediate_critical + daily_digest_warnings + digest_time picker + dedup_hours
- **Types d'alertes** — 12 toggles (one per AlertType), default ON (opt-out model)

## Storage

Maps to existing `GroupMemberNotificationPreference` — no new schema. UI inverts `disabled_alert_types` to per-type booleans for the form, inverts back on save.

## Nav

New "Mon compte" group, sort 100 (last), so the primary analytics nav stays clean.

## Tests

7 structural (slug, nav, HasForms contract, AlertType coverage, default-ON invariant, save inversion, digest options). 240 group tests pass, 697 assertions, 0 regression.

## Type

feat