### PR TITLE
feat(group-portal): PR7e storage ingestion infra

### DIFF
--- a/app/Console/Commands/TenantUpdateStorage.php
+++ b/app/Console/Commands/TenantUpdateStorage.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tenant;
+use App\Services\StorageIngestionService;
+use Illuminate\Console\Command;
+
+class TenantUpdateStorage extends Command
+{
+    protected $signature = 'tenant:update-storage {--tenant= : Limit to a single tenant code for testing}';
+
+    protected $description = 'Measures actual disk usage per tenant (via SSH `du`) and updates tenants.current_storage_mb. Unblocks the storage quota alert.';
+
+    public function handle(StorageIngestionService $ingestion): int
+    {
+        if (! config('group_portal.storage_ingestion_enabled', false)) {
+            $this->info('group_portal.storage_ingestion_enabled is false — nothing to do.');
+            return self::SUCCESS;
+        }
+
+        $query = Tenant::query()->where('status', 'active');
+        if ($code = $this->option('tenant')) {
+            $query->where('code', $code);
+        }
+
+        $tenants = $query->get();
+        $updated = 0;
+        $skipped = 0;
+
+        foreach ($tenants as $tenant) {
+            $mb = $ingestion->measureTenantStorageMb($tenant);
+
+            if ($mb === null) {
+                $skipped++;
+                continue;
+            }
+
+            // Only update when we have a real measurement — never overwrite
+            // a previous value with 0 because the ingestion failed.
+            $tenant->update(['current_storage_mb' => $mb]);
+            $updated++;
+            $this->line("[{$tenant->code}] updated: {$mb} MB");
+        }
+
+        $this->info("Storage ingestion complete — {$updated} updated, {$skipped} skipped, {$tenants->count()} total.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/StorageIngestionService.php
+++ b/app/Services/StorageIngestionService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Tenant;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+/**
+ * Measures a tenant's actual disk usage and persists it to
+ * `tenants.current_storage_mb`. Unblocks the storage alert path — PR-C's
+ * `collectQuotaAlerts` already fires when the ratio crosses thresholds,
+ * but it's been a no-op because the column was never populated (see
+ * `TenantConnectionManager.php:154-156` TODO).
+ *
+ * All KLASSCI tenants currently share a single cPanel account on the same
+ * host (`c2569688c@web44.lws-hosting.com`), so we shell out via SSH + `du`
+ * from the master app. When the topology grows, split the SSH executor
+ * into a per-tenant strategy.
+ *
+ * Dev environments have no SSH credentials — the service silent-fails with
+ * a logged warning and returns null so `tenant:update-storage` can run
+ * locally without crashing.
+ */
+class StorageIngestionService
+{
+    /**
+     * Returns disk usage in MB, or null if ingestion is disabled / fails.
+     * Caller decides what to do with null (typically: skip update, don't
+     * overwrite the previous value with 0).
+     */
+    public function measureTenantStorageMb(Tenant $tenant): ?int
+    {
+        if (! config('group_portal.storage_ingestion_enabled', false)) {
+            return null;
+        }
+
+        $host = (string) config('group_portal.storage_ssh_host', '');
+        $user = (string) config('group_portal.storage_ssh_user', '');
+        $basePath = rtrim((string) config('group_portal.storage_tenant_base_path', ''), '/');
+
+        if ($host === '' || $user === '' || $basePath === '' || $tenant->subdomain === null) {
+            Log::warning('[storage-ingestion] missing configuration — skipping', [
+                'tenant' => $tenant->code,
+                'host_set' => $host !== '',
+                'user_set' => $user !== '',
+                'base_path_set' => $basePath !== '',
+            ]);
+            return null;
+        }
+
+        $remotePath = $basePath . '/' . $tenant->subdomain;
+        $sshCommand = $this->buildSshCommand($user, $host, $remotePath);
+        $timeout = (int) config('group_portal.storage_ssh_timeout_sec', 30);
+
+        try {
+            $result = Process::timeout($timeout)->run($sshCommand);
+
+            if (! $result->successful()) {
+                Log::warning('[storage-ingestion] SSH du failed', [
+                    'tenant' => $tenant->code,
+                    'exit_code' => $result->exitCode(),
+                    'stderr' => substr($result->errorOutput(), 0, 500),
+                ]);
+                return null;
+            }
+
+            return $this->parseDuOutput($result->output());
+        } catch (\Throwable $e) {
+            Log::warning('[storage-ingestion] command threw', [
+                'tenant' => $tenant->code,
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * `du -sm` output shape: `<size>\t<path>\n`. We take the first column
+     * and coerce to int. Empty / malformed output returns null so the
+     * caller can distinguish "measurement failed" from "genuinely 0 MB".
+     */
+    public function parseDuOutput(string $rawOutput): ?int
+    {
+        $trimmed = trim($rawOutput);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        $firstField = preg_split('/\s+/', $trimmed, 2)[0] ?? '';
+        if (! is_numeric($firstField)) {
+            return null;
+        }
+
+        return max(0, (int) $firstField);
+    }
+
+    /**
+     * Escapes path for safe inclusion in the remote shell command. Tenant
+     * subdomains come from the `tenants` table (controlled by ops), but
+     * defense-in-depth: if a comma or space ever sneaks in, escapeshellarg
+     * prevents it becoming a remote command injection vector.
+     */
+    public function buildSshCommand(string $user, string $host, string $remotePath): string
+    {
+        $sshOptions = '-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new';
+
+        return sprintf(
+            'ssh %s %s@%s "du -sm %s"',
+            $sshOptions,
+            escapeshellarg($user),
+            escapeshellarg($host),
+            escapeshellarg($remotePath),
+        );
+    }
+}

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -143,4 +143,30 @@ return [
     | member's dedup_hours window is skipped silently.
     */
     'notifications_enabled' => env('GROUP_PORTAL_NOTIFICATIONS_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage ingestion (PR7e)
+    |--------------------------------------------------------------------------
+    |
+    | Populates `tenants.current_storage_mb` from real disk usage via SSH +
+    | `du -sm`. Once populated, the existing `collectQuotaAlerts` starts
+    | firing for storage — no additional alert plumbing needed.
+    |
+    | Default OFF so local dev doesn't crash on missing SSH credentials.
+    | Production enables via env:
+    |
+    |   GROUP_PORTAL_STORAGE_INGESTION_ENABLED=true
+    |   GROUP_PORTAL_STORAGE_SSH_HOST=web44.lws-hosting.com
+    |   GROUP_PORTAL_STORAGE_SSH_USER=c2569688c
+    |   GROUP_PORTAL_STORAGE_TENANT_BASE_PATH=/home/c2569688c/public_html
+    |
+    | SSH keys must be deployed on the master host in the runtime user's
+    | ~/.ssh — we don't embed them in config.
+    */
+    'storage_ingestion_enabled' => env('GROUP_PORTAL_STORAGE_INGESTION_ENABLED', false),
+    'storage_ssh_host' => env('GROUP_PORTAL_STORAGE_SSH_HOST', ''),
+    'storage_ssh_user' => env('GROUP_PORTAL_STORAGE_SSH_USER', ''),
+    'storage_tenant_base_path' => env('GROUP_PORTAL_STORAGE_TENANT_BASE_PATH', ''),
+    'storage_ssh_timeout_sec' => env('GROUP_PORTAL_STORAGE_SSH_TIMEOUT_SEC', 30),
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -155,3 +155,18 @@ scheduleWithTimestamp(
     storage_path('logs/group-digests.log'),
     'group:send-alert-digests'
 );
+
+// Storage ingestion — nightly run populates tenants.current_storage_mb
+// from real disk usage. Once populated, collectQuotaAlerts fires storage
+// alerts naturally. Skipped when the feature flag is off.
+scheduleWithTimestamp(
+    Schedule::command('tenant:update-storage')
+        ->dailyAt('03:30')
+        ->withoutOverlapping()
+        ->runInBackground()
+        ->skip(fn () => ! config('group_portal.storage_ingestion_enabled', false))
+        ->onSuccess(fn () => \Log::info('✅ Tenant storage ingestion complete'))
+        ->onFailure(fn () => \Log::error('❌ Tenant storage ingestion failed')),
+    storage_path('logs/storage-ingestion.log'),
+    'tenant:update-storage'
+);

--- a/tests/Feature/Group/StorageIngestionCommandTest.php
+++ b/tests/Feature/Group/StorageIngestionCommandTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+it('tenant:update-storage respects the kill switch', function () {
+    config()->set('group_portal.storage_ingestion_enabled', false);
+
+    $exit = Artisan::call('tenant:update-storage');
+    $output = Artisan::output();
+
+    expect($exit)->toBe(0);
+    expect($output)->toContain('storage_ingestion_enabled is false');
+});
+
+it('storage ingestion config keys ship with safe defaults', function () {
+    expect(config('group_portal.storage_ingestion_enabled'))->toBeFalse();
+    expect(config('group_portal.storage_ssh_timeout_sec'))->toBe(30);
+});
+
+it('storage ingestion command class is registered', function () {
+    $commands = array_keys(Artisan::all());
+
+    expect($commands)->toContain('tenant:update-storage');
+});
+
+it('scheduler wires tenant:update-storage behind the feature flag', function () {
+    $source = file_get_contents(base_path('routes/console.php'));
+
+    expect($source)->toContain("Schedule::command('tenant:update-storage')");
+    expect($source)->toContain("dailyAt('03:30')");
+    expect($source)->toContain("config('group_portal.storage_ingestion_enabled'");
+});

--- a/tests/Unit/Services/StorageIngestionServiceTest.php
+++ b/tests/Unit/Services/StorageIngestionServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Models\Tenant;
+use App\Services\StorageIngestionService;
+
+it('parses du -sm output and returns the first numeric field', function () {
+    $service = new StorageIngestionService();
+
+    expect($service->parseDuOutput("1234\t/home/c2569688c/public_html/rostan\n"))->toBe(1234);
+    expect($service->parseDuOutput("0\t/some/path"))->toBe(0);
+    expect($service->parseDuOutput("  987   /padded/path  "))->toBe(987);
+});
+
+it('returns null for empty or malformed du output', function () {
+    $service = new StorageIngestionService();
+
+    expect($service->parseDuOutput(''))->toBeNull();
+    expect($service->parseDuOutput("   \n   "))->toBeNull();
+    expect($service->parseDuOutput("not_a_number\t/path"))->toBeNull();
+});
+
+it('clamps negative values to zero (defensive against weird du output)', function () {
+    $service = new StorageIngestionService();
+
+    expect($service->parseDuOutput("-1\t/path"))->toBe(0);
+});
+
+it('builds the SSH command with defensive shell escaping', function () {
+    $service = new StorageIngestionService();
+
+    $cmd = $service->buildSshCommand('c2569688c', 'web44.lws-hosting.com', '/home/c2569688c/public_html/rostan');
+
+    expect($cmd)->toContain('ssh ');
+    expect($cmd)->toContain('-o BatchMode=yes');
+    expect($cmd)->toContain('-o ConnectTimeout=10');
+    expect($cmd)->toContain('du -sm');
+
+    // escapeshellarg() uses different quoting on Windows vs POSIX, so assert
+    // the raw values appear (quoted in either flavor) rather than hard-coding
+    // the quote character.
+    expect($cmd)->toContain('c2569688c');
+    expect($cmd)->toContain('web44.lws-hosting.com');
+    expect($cmd)->toContain('/home/c2569688c/public_html/rostan');
+});
+
+it('measureTenantStorageMb returns null when the feature flag is off', function () {
+    config()->set('group_portal.storage_ingestion_enabled', false);
+
+    $tenant = new Tenant();
+    $tenant->setRawAttributes(['code' => 'test', 'subdomain' => 'test'], true);
+
+    expect(app(StorageIngestionService::class)->measureTenantStorageMb($tenant))->toBeNull();
+});
+
+it('measureTenantStorageMb returns null when configuration is incomplete', function () {
+    config()->set('group_portal.storage_ingestion_enabled', true);
+    config()->set('group_portal.storage_ssh_host', '');
+    config()->set('group_portal.storage_ssh_user', 'c2569688c');
+    config()->set('group_portal.storage_tenant_base_path', '/home/c2569688c/public_html');
+
+    $tenant = new Tenant();
+    $tenant->setRawAttributes(['code' => 'test', 'subdomain' => 'test'], true);
+
+    expect(app(StorageIngestionService::class)->measureTenantStorageMb($tenant))->toBeNull();
+});
+
+it('measureTenantStorageMb returns null when tenant has no subdomain', function () {
+    config()->set('group_portal.storage_ingestion_enabled', true);
+    config()->set('group_portal.storage_ssh_host', 'test.host');
+    config()->set('group_portal.storage_ssh_user', 'user');
+    config()->set('group_portal.storage_tenant_base_path', '/base');
+
+    $tenant = new Tenant();
+    $tenant->setRawAttributes(['code' => 'test', 'subdomain' => null], true);
+
+    expect(app(StorageIngestionService::class)->measureTenantStorageMb($tenant))->toBeNull();
+});


### PR DESCRIPTION
## Summary

Unblocks the storage quota alert (tracked as `collectQuotaAlerts` for storage — previously a no-op because `tenants.current_storage_mb` was never populated per `TenantConnectionManager.php:154-156` TODO).

- `StorageIngestionService` — SSH + `du -sm` per tenant, null on failure/flag-off
- `tenant:update-storage` artisan command — iterates active tenants, updates column only on real measurement
- Scheduler: daily 03:30, skipped when flag off
- Config: 5 new env vars, all default safe (flag OFF)

## Why no new alert type

`collectQuotaAlerts` already handles storage in the generic quota branch. Once `current_storage_mb` flows, Warning @ 90% and Critical @ 100% fire through the existing path. No PR7f polish needed — the existing message is actionable enough.

## Production activation

Deploy an SSH key for the master-app runtime user into the cPanel account, set the env vars, flip `GROUP_PORTAL_STORAGE_INGESTION_ENABLED=true`.

## Tests

11 new (7 unit service + 4 feature command). 121 group+storage tests pass, 294 assertions, 0 regression.

## Type

feat