### PR TITLE
chore(group-portal): post-marathon simplifications + silent-failure fixes

### DIFF
--- a/app/Console/Commands/TenantUpdateStorage.php
+++ b/app/Console/Commands/TenantUpdateStorage.php
@@ -45,6 +45,17 @@ class TenantUpdateStorage extends Command
 
         $this->info("Storage ingestion complete — {$updated} updated, {$skipped} skipped, {$tenants->count()} total.");
 
+        // Total failure (every tenant skipped, nothing updated) surfaces as a
+        // non-zero exit so cron job monitoring catches silent ingestion outages.
+        // Some skips are fine; ALL skips with zero successes = ops problem.
+        if ($tenants->count() > 0 && $updated === 0) {
+            \Log::error('[storage-ingestion] every tenant skipped — ingestion pipeline likely broken', [
+                'total' => $tenants->count(),
+                'skipped' => $skipped,
+            ]);
+            return self::FAILURE;
+        }
+
         return self::SUCCESS;
     }
 }

--- a/app/Mail/Group/AbstractGroupAlertMail.php
+++ b/app/Mail/Group/AbstractGroupAlertMail.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Mail\Group;
+
+use App\Models\Group;
+use App\Models\GroupMember;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Shared plumbing for every notification email the group portal sends.
+ * Concrete subclasses decide only subject + view + payload shape; the retry
+ * policy, queueability, and signed-unsubscribe URL construction live here.
+ */
+abstract class AbstractGroupAlertMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public array $backoff = [30, 120, 300];
+
+    public function __construct(
+        public Group $group,
+        public GroupMember $member,
+    ) {
+    }
+
+    /**
+     * Every alert email footer offers a one-click opt-out. The `type` path
+     * parameter decides what gets disabled when the link is clicked:
+     *   - an AlertType::value string → adds to disabled_alert_types
+     *   - 'digest' → flips daily_digest_warnings off
+     *   - anything else → falls through to email_enabled = false (kill all)
+     */
+    protected function buildUnsubscribeUrl(string $type): string
+    {
+        return URL::signedRoute('groupe.notifications.unsubscribe', [
+            'member' => $this->member->id,
+            'type' => $type,
+        ]);
+    }
+}

--- a/app/Mail/Group/CriticalAlertMail.php
+++ b/app/Mail/Group/CriticalAlertMail.php
@@ -4,36 +4,21 @@ namespace App\Mail\Group;
 
 use App\Models\Group;
 use App\Models\GroupMember;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Mail\Mailable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\URL;
 
-class CriticalAlertMail extends Mailable implements ShouldQueue
+class CriticalAlertMail extends AbstractGroupAlertMail
 {
-    use Queueable, SerializesModels;
-
-    public int $tries = 3;
-
-    public array $backoff = [30, 120, 300];
-
     public function __construct(
-        public Group $group,
-        public GroupMember $member,
+        Group $group,
+        GroupMember $member,
         public array $alert,
     ) {
+        parent::__construct($group, $member);
     }
 
     public function build(): self
     {
-        $typeLabel = $this->alert['type'] ?? 'alerte';
         $tenant = $this->alert['tenant_name'] ?? $this->alert['tenant_code'] ?? $this->group->name;
-
-        $unsubscribeUrl = URL::signedRoute('groupe.notifications.unsubscribe', [
-            'member' => $this->member->id,
-            'type' => $typeLabel,
-        ]);
+        $type = $this->alert['type'] ?? 'alerte';
 
         return $this->subject("[KLASSCI] Alerte critique — {$tenant}")
             ->view('emails.group.critical-alert')
@@ -41,7 +26,7 @@ class CriticalAlertMail extends Mailable implements ShouldQueue
                 'group' => $this->group,
                 'member' => $this->member,
                 'alert' => $this->alert,
-                'unsubscribeUrl' => $unsubscribeUrl,
+                'unsubscribeUrl' => $this->buildUnsubscribeUrl($type),
             ]);
     }
 }

--- a/app/Mail/Group/DailyAlertDigestMail.php
+++ b/app/Mail/Group/DailyAlertDigestMail.php
@@ -4,34 +4,20 @@ namespace App\Mail\Group;
 
 use App\Models\Group;
 use App\Models\GroupMember;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Mail\Mailable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\URL;
 
-class DailyAlertDigestMail extends Mailable implements ShouldQueue
+class DailyAlertDigestMail extends AbstractGroupAlertMail
 {
-    use Queueable, SerializesModels;
-
-    public int $tries = 3;
-
-    public array $backoff = [30, 120, 300];
-
     public function __construct(
-        public Group $group,
-        public GroupMember $member,
+        Group $group,
+        GroupMember $member,
         public array $alerts,
     ) {
+        parent::__construct($group, $member);
     }
 
     public function build(): self
     {
         $count = count($this->alerts);
-        $unsubscribeUrl = URL::signedRoute('groupe.notifications.unsubscribe', [
-            'member' => $this->member->id,
-            'type' => 'digest',
-        ]);
 
         return $this->subject("[KLASSCI] Récapitulatif quotidien — {$count} alerte" . ($count > 1 ? 's' : ''))
             ->view('emails.group.daily-digest')
@@ -39,7 +25,7 @@ class DailyAlertDigestMail extends Mailable implements ShouldQueue
                 'group' => $this->group,
                 'member' => $this->member,
                 'alerts' => $this->alerts,
-                'unsubscribeUrl' => $unsubscribeUrl,
+                'unsubscribeUrl' => $this->buildUnsubscribeUrl('digest'),
             ]);
     }
 }

--- a/app/Models/GroupMemberNotificationPreference.php
+++ b/app/Models/GroupMemberNotificationPreference.php
@@ -61,15 +61,14 @@ class GroupMemberNotificationPreference extends Model
      * True when the member has opted in for emails AND this specific
      * AlertType isn't in their disabled list.
      */
-    public function acceptsAlertType(AlertType|string $type): bool
+    public function acceptsAlertType(AlertType $type): bool
     {
         if (! $this->email_enabled) {
             return false;
         }
 
-        $value = $type instanceof AlertType ? $type->value : (string) $type;
         $disabled = (array) ($this->disabled_alert_types ?? []);
 
-        return ! in_array($value, $disabled, true);
+        return ! in_array($type->value, $disabled, true);
     }
 }

--- a/app/Services/Group/AlertNotificationDispatcher.php
+++ b/app/Services/Group/AlertNotificationDispatcher.php
@@ -3,6 +3,7 @@
 namespace App\Services\Group;
 
 use App\Enums\AlertSeverity;
+use App\Enums\AlertType;
 use App\Mail\Group\CriticalAlertMail;
 use App\Mail\Group\DailyAlertDigestMail;
 use App\Models\Group;
@@ -78,7 +79,19 @@ class AlertNotificationDispatcher
                 }
 
                 $fingerprint = $this->fingerprints->generate($group->id, $alert);
-                if (GroupAlertNotificationLog::wasRecentlyNotified($member->id, $fingerprint, $prefs->dedup_hours)) {
+
+                // Dedup check in its own try/catch so a DB failure doesn't get
+                // miscategorised as a mail-send failure in the logs downstream.
+                try {
+                    if (GroupAlertNotificationLog::wasRecentlyNotified($member->id, $fingerprint, $prefs->dedup_hours)) {
+                        continue;
+                    }
+                } catch (\Throwable $e) {
+                    Log::error('[group-notifications] dedup check failed — skipping to avoid duplicate send', [
+                        'group' => $group->code,
+                        'member' => $member->email,
+                        'error' => $e->getMessage(),
+                    ]);
                     continue;
                 }
 
@@ -149,7 +162,17 @@ class AlertNotificationDispatcher
                 }
 
                 $fingerprint = $this->fingerprints->generate($group->id, $alert);
-                if (GroupAlertNotificationLog::wasRecentlyNotified($member->id, $fingerprint, $prefs->dedup_hours)) {
+
+                try {
+                    if (GroupAlertNotificationLog::wasRecentlyNotified($member->id, $fingerprint, $prefs->dedup_hours)) {
+                        continue;
+                    }
+                } catch (\Throwable $e) {
+                    Log::error('[group-notifications] dedup check failed during digest — skipping', [
+                        'group' => $group->code,
+                        'member' => $member->email,
+                        'error' => $e->getMessage(),
+                    ]);
                     continue;
                 }
 
@@ -185,12 +208,15 @@ class AlertNotificationDispatcher
 
     private function memberAcceptsAlert(GroupMember $member, GroupMemberNotificationPreference $prefs, array $alert): bool
     {
-        $type = $alert['type'] ?? null;
-        if ($type === null || ! $prefs->acceptsAlertType($type)) {
+        // Parse once — both downstream checks work with the enum case directly,
+        // avoiding two separate AlertType::tryFrom() conversions.
+        $type = AlertType::tryFrom($alert['type'] ?? '');
+        if ($type === null) {
             return false;
         }
 
-        return $this->roleMatcher->isSubscribedByValue($member->role, $type);
+        return $prefs->acceptsAlertType($type)
+            && $this->roleMatcher->isSubscribed($member->role, $type);
     }
 
     private function isWithinDigestSlot(GroupMemberNotificationPreference $prefs): bool

--- a/app/Services/Group/AlertRoleMatcher.php
+++ b/app/Services/Group/AlertRoleMatcher.php
@@ -35,11 +35,4 @@ class AlertRoleMatcher
             default => false,
         };
     }
-
-    public function isSubscribedByValue(string $role, string $typeValue): bool
-    {
-        $type = AlertType::tryFrom($typeValue);
-
-        return $type !== null && $this->isSubscribed($role, $type);
-    }
 }

--- a/tests/Unit/Services/Group/AlertRoleMatcherTest.php
+++ b/tests/Unit/Services/Group/AlertRoleMatcherTest.php
@@ -43,9 +43,13 @@ it('unknown roles receive nothing (default-deny)', function () {
     expect($matcher->isSubscribed('', AlertType::UnpaidInvoices))->toBeFalse();
 });
 
-it('isSubscribedByValue handles invalid AlertType strings gracefully', function () {
+it('isSubscribed requires a typed AlertType (string variant removed post-simplify)', function () {
     $matcher = new AlertRoleMatcher();
 
-    expect($matcher->isSubscribedByValue('fondateur', 'not_a_real_type'))->toBeFalse();
-    expect($matcher->isSubscribedByValue('fondateur', 'subscription_expired'))->toBeTrue();
+    // The string-based thin wrapper was inlined into the dispatcher where the
+    // AlertType::tryFrom() + null guard already happen. Nothing here to test
+    // beyond the typed path covered above — this test pins the surface so
+    // a future refactor doesn't quietly reintroduce the string API.
+    $reflection = new ReflectionClass($matcher);
+    expect($reflection->hasMethod('isSubscribedByValue'))->toBeFalse();
 });


### PR DESCRIPTION
## Summary

Follow-up to the 8-PR marathon (#37→#44). Applies the actionable findings from `/simplify` + silent-failure-hunter agent review.

## Simplifications

- Drop dead `AlertRoleMatcher::isSubscribedByValue` — indirection without value
- Consolidate double `tryFrom` in `memberAcceptsAlert`
- Tighten `acceptsAlertType` signature to `AlertType` only (drop dead string path)
- Extract `AbstractGroupAlertMail` base — hoists tries/backoff/ShouldQueue/unsubscribe URL

## Silent-failure fixes

- `TenantUpdateStorage` returns FAILURE exit code when 100% of tenants skip (previously success hid total pipeline breakage)
- `wasRecentlyNotified` wrapped in own try/catch — DB failures no longer mislabelled as mail-send failures

## Deferred (follow-up PRs)

- `safeTenantQuery` helper to dedupe 5× try/finally in `TenantAggregationService`
- `AlertPayload` readonly DTO replacing ad-hoc arrays
- Sunset ticket for `TIER_*` string constants after 2 deploy cycles

## Tests

251 pass, 721 assertions, 0 regression.

## Type

chore