### PR TITLE
fix(group-portal): add missing AlertType labels for filter dropdown

### DIFF
--- a/resources/views/filament/group/pages/alerts-index.blade.php
+++ b/resources/views/filament/group/pages/alerts-index.blade.php
@@ -15,6 +15,8 @@
         AlertType::StaleTenant->value => 'Tenant inactif',
         AlertType::SslExpiring->value => 'SSL expirant',
         AlertType::EnrollmentDecline->value => 'Inscriptions en baisse',
+        AlertType::UnpaidInvoices->value => 'Factures impayées',
+        AlertType::TeacherOverload->value => 'Surcharge enseignante',
     ];
 @endphp
 


### PR DESCRIPTION
## Summary

Phase 1 regression found during visual check quality gate.

`UnpaidInvoices` + `TeacherOverload` étaient absents du `$typeLabels` sur `/groupe/alertes`, donc les 2 AlertTypes ajoutés en PR7c + PR7d n'apparaissaient pas dans le dropdown de filtre TYPE. `NotificationPreferences.php` avait déjà les bons labels, `alerts-index.blade.php` pas.

## Visual check résultats (/groupe complet)

| Page | Status |
|------|--------|
| `/groupe` dashboard + banner | ✅ PASS |
| `/groupe/alertes` | ⚠️ REGRESSION — 2 types manquants dans dropdown (fixed) |
| `/groupe/mes-preferences-notifications` | ✅ PASS (12 AlertType toggles tous présents) |
| `/groupe/establishments` | ✅ PASS |
| Banner tone urgent | ✅ PASS (test induit subscription_end_date = now+5d) |
| A11y banner | ✅ role=alert + aria-live=assertive |
| Alerts widget empty state | ✅ PASS |
| Sidebar badge count | ✅ PASS (affiche 1 quand alert fire) |

## Fix

```diff
        AlertType::SslExpiring->value => 'SSL expirant',
        AlertType::EnrollmentDecline->value => 'Inscriptions en baisse',
+       AlertType::UnpaidInvoices->value => 'Factures impayées',
+       AlertType::TeacherOverload->value => 'Surcharge enseignante',
    ];
```

## Type

fix