### PR TITLE
refactor(group-portal): AlertPayload readonly DTO (#46)

### DIFF
--- a/app/Filament/Group/Pages/AlertsIndex.php
+++ b/app/Filament/Group/Pages/AlertsIndex.php
@@ -4,6 +4,7 @@ namespace App\Filament\Group\Pages;
 
 use App\Filament\Group\Concerns\HasCustomHero;
 use App\Services\TenantAggregationService;
+use App\Support\Alerts\AlertPayload;
 use Filament\Pages\Page;
 
 /**
@@ -46,13 +47,15 @@ class AlertsIndex extends Page
         // can filter acknowledged ones without a server round-trip. Same
         // tenant+type combo is considered the "same" alert across polls —
         // message text changes (e.g. days remaining) don't break the ack.
-        return array_map(function (array $alert) use ($dismissed) {
-            $fingerprint = $this->fingerprintOf($alert);
-            $alert['fingerprint'] = $fingerprint;
-            $alert['acknowledged'] = isset($dismissed[$fingerprint])
+        return array_map(function ($alert) use ($dismissed) {
+            $payload = AlertPayload::from($alert);
+            $row = $payload->toArray();
+            $fingerprint = $this->fingerprintOf($payload);
+            $row['fingerprint'] = $fingerprint;
+            $row['acknowledged'] = isset($dismissed[$fingerprint])
                 && now()->lessThan($dismissed[$fingerprint]);
 
-            return $alert;
+            return $row;
         }, $alerts);
     }
 
@@ -90,8 +93,8 @@ class AlertsIndex extends Page
         return app(TenantAggregationService::class)->getGroupHealthMetrics($group);
     }
 
-    private function fingerprintOf(array $alert): string
+    private function fingerprintOf(AlertPayload $alert): string
     {
-        return md5(($alert['tenant_code'] ?? '') . '|' . ($alert['type'] ?? ''));
+        return md5(($alert->tenantCode ?? '') . '|' . $alert->type->value);
     }
 }

--- a/app/Filament/Group/Resources/EstablishmentResource.php
+++ b/app/Filament/Group/Resources/EstablishmentResource.php
@@ -89,7 +89,7 @@ class EstablishmentResource extends Resource
         }
 
         foreach ($alerts as $alert) {
-            if (($alert['severity'] ?? null) === AlertSeverity::Critical->value) {
+            if (\App\Support\Alerts\AlertPayload::from($alert)->severity === AlertSeverity::Critical) {
                 return 'danger';
             }
         }

--- a/app/Filament/Group/Widgets/GroupAlertsWidget.php
+++ b/app/Filament/Group/Widgets/GroupAlertsWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Group\Widgets;
 
 use App\Services\TenantAggregationService;
+use App\Support\Alerts\AlertPayload;
 use Filament\Widgets\Widget;
 
 class GroupAlertsWidget extends Widget
@@ -21,10 +22,14 @@ class GroupAlertsWidget extends Widget
         $service = app(TenantAggregationService::class);
 
         $health = $service->getGroupHealthMetrics($group);
+        $alerts = array_map(
+            fn ($alert) => AlertPayload::from($alert)->toArray(),
+            $health['alerts']
+        );
 
         return [
-            'alerts' => array_slice($health['alerts'], 0, 5),
-            'totalAlerts' => count($health['alerts']),
+            'alerts' => array_slice($alerts, 0, 5),
+            'totalAlerts' => count($alerts),
             'quotaCriticalCount' => $health['quota_critical_count'],
             'quotaExceededCount' => $health['quota_exceeded_count'],
             'subscriptionExpiringCount' => $health['subscription_expiring_count'],

--- a/app/Mail/Group/CriticalAlertMail.php
+++ b/app/Mail/Group/CriticalAlertMail.php
@@ -4,21 +4,23 @@ namespace App\Mail\Group;
 
 use App\Models\Group;
 use App\Models\GroupMember;
+use App\Support\Alerts\AlertPayload;
 
 class CriticalAlertMail extends AbstractGroupAlertMail
 {
     public function __construct(
         Group $group,
         GroupMember $member,
-        public array $alert,
+        public AlertPayload $alert,
     ) {
         parent::__construct($group, $member);
     }
 
     public function build(): self
     {
-        $tenant = $this->alert['tenant_name'] ?? $this->alert['tenant_code'] ?? $this->group->name;
-        $type = $this->alert['type'] ?? 'alerte';
+        $tenant = $this->alert->tenantName !== ''
+            ? $this->alert->tenantName
+            : ($this->alert->tenantCode ?? $this->group->name);
 
         return $this->subject("[KLASSCI] Alerte critique — {$tenant}")
             ->view('emails.group.critical-alert')
@@ -26,7 +28,7 @@ class CriticalAlertMail extends AbstractGroupAlertMail
                 'group' => $this->group,
                 'member' => $this->member,
                 'alert' => $this->alert,
-                'unsubscribeUrl' => $this->buildUnsubscribeUrl($type),
+                'unsubscribeUrl' => $this->buildUnsubscribeUrl($this->alert->type->value),
             ]);
     }
 }

--- a/app/Mail/Group/DailyAlertDigestMail.php
+++ b/app/Mail/Group/DailyAlertDigestMail.php
@@ -4,9 +4,13 @@ namespace App\Mail\Group;
 
 use App\Models\Group;
 use App\Models\GroupMember;
+use App\Support\Alerts\AlertPayload;
 
 class DailyAlertDigestMail extends AbstractGroupAlertMail
 {
+    /**
+     * @param  array<int, AlertPayload>  $alerts
+     */
     public function __construct(
         Group $group,
         GroupMember $member,

--- a/app/Services/Group/AlertFingerprintGenerator.php
+++ b/app/Services/Group/AlertFingerprintGenerator.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Group;
 
+use App\Support\Alerts\AlertPayload;
+
 /**
  * Deterministic fingerprint per alert, used by the dedup layer to avoid
  * spamming the same alert to the same recipient within a time window.
@@ -12,16 +14,13 @@ namespace App\Services\Group;
  */
 class AlertFingerprintGenerator
 {
-    /**
-     * @param  array{tenant_code?: string, type: string, severity: string}  $alert
-     */
-    public function generate(int $groupId, array $alert): string
+    public function generate(int $groupId, AlertPayload $alert): string
     {
         $payload = implode('|', [
             $groupId,
-            $alert['tenant_code'] ?? '',
-            $alert['type'] ?? '',
-            $alert['severity'] ?? '',
+            $alert->tenantCode ?? '',
+            $alert->type->value,
+            $alert->severity->value,
         ]);
 
         return hash('sha256', $payload);

--- a/app/Services/Group/AlertNotificationDispatcher.php
+++ b/app/Services/Group/AlertNotificationDispatcher.php
@@ -3,7 +3,6 @@
 namespace App\Services\Group;
 
 use App\Enums\AlertSeverity;
-use App\Enums\AlertType;
 use App\Mail\Group\CriticalAlertMail;
 use App\Mail\Group\DailyAlertDigestMail;
 use App\Models\Group;
@@ -11,6 +10,7 @@ use App\Models\GroupAlertNotificationLog;
 use App\Models\GroupMember;
 use App\Models\GroupMemberNotificationPreference;
 use App\Services\TenantAggregationService;
+use App\Support\Alerts\AlertPayload;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
@@ -52,7 +52,8 @@ class AlertNotificationDispatcher
 
         $health = $this->aggregationService->getGroupHealthMetrics($group);
         $alerts = collect($health['alerts'] ?? [])
-            ->filter(fn ($alert) => ($alert['severity'] ?? '') === AlertSeverity::Critical->value)
+            ->map(fn ($alert) => AlertPayload::from($alert))
+            ->filter(fn (AlertPayload $alert) => $alert->severity === AlertSeverity::Critical)
             ->values()
             ->all();
 
@@ -103,7 +104,7 @@ class AlertNotificationDispatcher
                     Log::error('[group-notifications] immediate dispatch failed', [
                         'group' => $group->code,
                         'member' => $member->email,
-                        'alert_type' => $alert['type'] ?? 'unknown',
+                        'alert_type' => $alert->type->value,
                         'error' => $e->getMessage(),
                     ]);
                 }
@@ -128,11 +129,11 @@ class AlertNotificationDispatcher
         }
 
         $health = $this->aggregationService->getGroupHealthMetrics($group);
-        $allAlerts = $health['alerts'] ?? [];
-        $warningAlerts = array_values(array_filter(
-            $allAlerts,
-            fn ($alert) => ($alert['severity'] ?? '') === AlertSeverity::Warning->value
-        ));
+        $warningAlerts = collect($health['alerts'] ?? [])
+            ->map(fn ($alert) => AlertPayload::from($alert))
+            ->filter(fn (AlertPayload $alert) => $alert->severity === AlertSeverity::Warning)
+            ->values()
+            ->all();
 
         if (empty($warningAlerts)) {
             return 0;
@@ -206,17 +207,10 @@ class AlertNotificationDispatcher
         return $sentCount;
     }
 
-    private function memberAcceptsAlert(GroupMember $member, GroupMemberNotificationPreference $prefs, array $alert): bool
+    private function memberAcceptsAlert(GroupMember $member, GroupMemberNotificationPreference $prefs, AlertPayload $alert): bool
     {
-        // Parse once — both downstream checks work with the enum case directly,
-        // avoiding two separate AlertType::tryFrom() conversions.
-        $type = AlertType::tryFrom($alert['type'] ?? '');
-        if ($type === null) {
-            return false;
-        }
-
-        return $prefs->acceptsAlertType($type)
-            && $this->roleMatcher->isSubscribed($member->role, $type);
+        return $prefs->acceptsAlertType($alert->type)
+            && $this->roleMatcher->isSubscribed($member->role, $alert->type);
     }
 
     private function isWithinDigestSlot(GroupMemberNotificationPreference $prefs): bool
@@ -238,14 +232,14 @@ class AlertNotificationDispatcher
         return true;
     }
 
-    private function logDispatch(Group $group, GroupMember $member, array $alert, string $fingerprint, string $channel): void
+    private function logDispatch(Group $group, GroupMember $member, AlertPayload $alert, string $fingerprint, string $channel): void
     {
         GroupAlertNotificationLog::create([
             'group_member_id' => $member->id,
             'group_id' => $group->id,
-            'tenant_code' => $alert['tenant_code'] ?? null,
-            'alert_type' => $alert['type'] ?? 'unknown',
-            'severity' => $alert['severity'] ?? 'info',
+            'tenant_code' => $alert->tenantCode,
+            'alert_type' => $alert->type->value,
+            'severity' => $alert->severity->value,
             'fingerprint' => $fingerprint,
             'channel' => $channel,
             'sent_at' => now(),

--- a/app/Services/TenantAggregationService.php
+++ b/app/Services/TenantAggregationService.php
@@ -14,6 +14,7 @@ use App\Services\Group\SubscriptionTierResolver;
 use App\Services\Group\TeacherWorkloadResolver;
 use App\Services\Group\TenantAggregator;
 use App\Services\Group\TenantBillingContext;
+use App\Support\Alerts\AlertPayload;
 use App\Support\Period\PeriodFactory;
 use App\Support\Period\PeriodInterface;
 use Illuminate\Support\Facades\Cache;
@@ -493,21 +494,15 @@ class TenantAggregationService
 
         usort(
             $health['alerts'],
-            fn ($a, $b) => AlertSeverity::from($a['severity'])->sortOrder() <=> AlertSeverity::from($b['severity'])->sortOrder()
+            fn ($a, $b) => $a->severity->sortOrder() <=> $b->severity->sortOrder()
         );
 
         return $health;
     }
 
-    private function buildAlert(Tenant $tenant, AlertSeverity $severity, AlertType $type, string $message): array
+    private function buildAlert(Tenant $tenant, AlertSeverity $severity, AlertType $type, string $message): AlertPayload
     {
-        return [
-            'severity' => $severity->value,
-            'tenant_code' => $tenant->code,
-            'tenant_name' => $tenant->name,
-            'type' => $type->value,
-            'message' => $message,
-        ];
+        return AlertPayload::make($tenant, $severity, $type, $message);
     }
 
     /**

--- a/app/Support/Alerts/AlertPayload.php
+++ b/app/Support/Alerts/AlertPayload.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Support\Alerts;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertType;
+use App\Models\Tenant;
+
+/**
+ * Typed snapshot of one alert emitted by the aggregation pipeline.
+ *
+ * Replaces the ad-hoc `array $alert` passed between TenantAggregationService,
+ * AlertFingerprintGenerator, AlertRoleMatcher, AlertNotificationDispatcher,
+ * GroupAlertNotificationLog, and the Mailables. The shape is enforced at the
+ * type system so the six scattered `?? 'unknown'` / `?? ''` null-coalesces
+ * disappear — if a field could ever be null, the DTO says so explicitly.
+ *
+ * `from()` accepts either an AlertPayload or the legacy array shape, so data
+ * that was cached under the old format before a deploy keeps working until
+ * the aggregation TTL flushes it (5 min).
+ */
+final readonly class AlertPayload
+{
+    public function __construct(
+        public AlertSeverity $severity,
+        public AlertType $type,
+        public string $tenantName,
+        public ?string $tenantCode,
+        public string $message,
+    ) {
+    }
+
+    public static function make(
+        Tenant $tenant,
+        AlertSeverity $severity,
+        AlertType $type,
+        string $message,
+    ): self {
+        return new self(
+            severity: $severity,
+            type: $type,
+            tenantName: $tenant->name,
+            tenantCode: $tenant->code,
+            message: $message,
+        );
+    }
+
+    /**
+     * Accepts either an AlertPayload (fast path) or the legacy array shape
+     * (cache compat during rollout). Returning the object type unconditionally
+     * lets consumers drop array-vs-object branching.
+     *
+     * @param  self|array{severity: string, type: string, tenant_name?: string, tenant_code?: string|null, message: string}  $alert
+     */
+    public static function from(self|array $alert): self
+    {
+        if ($alert instanceof self) {
+            return $alert;
+        }
+
+        return new self(
+            severity: AlertSeverity::from($alert['severity']),
+            type: AlertType::from($alert['type']),
+            tenantName: $alert['tenant_name'] ?? ($alert['tenant_code'] ?? ''),
+            tenantCode: $alert['tenant_code'] ?? null,
+            message: $alert['message'] ?? '',
+        );
+    }
+
+    /**
+     * Array form kept for Blade partials and tests that still read the
+     * dictionary shape. Keys match the historical $alert array exactly so
+     * the migration is a no-op for legacy consumers.
+     */
+    public function toArray(): array
+    {
+        return [
+            'severity' => $this->severity->value,
+            'tenant_code' => $this->tenantCode,
+            'tenant_name' => $this->tenantName,
+            'type' => $this->type->value,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/resources/views/emails/group/critical-alert.blade.php
+++ b/resources/views/emails/group/critical-alert.blade.php
@@ -10,9 +10,9 @@
     Une action immédiate peut être nécessaire pour éviter une interruption de service.</p>
 
     <div class="alert-card alert-critical">
-        <p class="alert-title">{{ $alert['message'] }}</p>
+        <p class="alert-title">{{ $alert->message }}</p>
         <p class="alert-tenant">
-            Établissement : <strong>{{ $alert['tenant_name'] ?? $alert['tenant_code'] ?? '—' }}</strong>
+            Établissement : <strong>{{ $alert->tenantName !== '' ? $alert->tenantName : ($alert->tenantCode ?? '—') }}</strong>
         </p>
     </div>
 

--- a/resources/views/emails/group/daily-digest.blade.php
+++ b/resources/views/emails/group/daily-digest.blade.php
@@ -11,9 +11,9 @@
 
     @foreach ($alerts as $alert)
         <div class="alert-card alert-warning">
-            <p class="alert-title">{{ $alert['message'] }}</p>
+            <p class="alert-title">{{ $alert->message }}</p>
             <p class="alert-tenant">
-                Établissement : <strong>{{ $alert['tenant_name'] ?? $alert['tenant_code'] ?? '—' }}</strong>
+                Établissement : <strong>{{ $alert->tenantName !== '' ? $alert->tenantName : ($alert->tenantCode ?? '—') }}</strong>
             </p>
         </div>
     @endforeach

--- a/tests/Unit/Services/Group/AlertFingerprintGeneratorTest.php
+++ b/tests/Unit/Services/Group/AlertFingerprintGeneratorTest.php
@@ -1,11 +1,25 @@
 <?php
 
+use App\Enums\AlertSeverity;
+use App\Enums\AlertType;
 use App\Services\Group\AlertFingerprintGenerator;
+use App\Support\Alerts\AlertPayload;
+
+function makePayload(string $tenantCode, AlertType $type, AlertSeverity $severity): AlertPayload
+{
+    return new AlertPayload(
+        severity: $severity,
+        type: $type,
+        tenantName: $tenantCode,
+        tenantCode: $tenantCode,
+        message: 'test',
+    );
+}
 
 it('generates the same fingerprint for the same (group, tenant, type, severity) tuple', function () {
     $generator = new AlertFingerprintGenerator();
 
-    $alert = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+    $alert = makePayload('rostan', AlertType::SslExpiring, AlertSeverity::Critical);
 
     $fp1 = $generator->generate(1, $alert);
     $fp2 = $generator->generate(1, $alert);
@@ -17,8 +31,8 @@ it('generates the same fingerprint for the same (group, tenant, type, severity) 
 it('changes fingerprint when severity escalates (so re-notify fires)', function () {
     $generator = new AlertFingerprintGenerator();
 
-    $warning = ['tenant_code' => 'rostan', 'type' => 'quota_critical', 'severity' => 'warning'];
-    $critical = ['tenant_code' => 'rostan', 'type' => 'quota_critical', 'severity' => 'critical'];
+    $warning = makePayload('rostan', AlertType::QuotaCritical, AlertSeverity::Warning);
+    $critical = makePayload('rostan', AlertType::QuotaCritical, AlertSeverity::Critical);
 
     expect($generator->generate(1, $warning))->not->toBe($generator->generate(1, $critical));
 });
@@ -26,8 +40,8 @@ it('changes fingerprint when severity escalates (so re-notify fires)', function 
 it('changes fingerprint when tenant differs (per-tenant dedup)', function () {
     $generator = new AlertFingerprintGenerator();
 
-    $tenantA = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'severity' => 'critical'];
-    $tenantB = ['tenant_code' => 'yakro', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+    $tenantA = makePayload('rostan', AlertType::SslExpiring, AlertSeverity::Critical);
+    $tenantB = makePayload('yakro', AlertType::SslExpiring, AlertSeverity::Critical);
 
     expect($generator->generate(1, $tenantA))->not->toBe($generator->generate(1, $tenantB));
 });
@@ -35,17 +49,24 @@ it('changes fingerprint when tenant differs (per-tenant dedup)', function () {
 it('changes fingerprint when group differs (cross-group isolation)', function () {
     $generator = new AlertFingerprintGenerator();
 
-    $alert = ['tenant_code' => 'rostan', 'type' => 'ssl_expiring', 'severity' => 'critical'];
+    $alert = makePayload('rostan', AlertType::SslExpiring, AlertSeverity::Critical);
 
     expect($generator->generate(1, $alert))->not->toBe($generator->generate(2, $alert));
 });
 
-it('handles missing keys without throwing (defensive against upstream drift)', function () {
+it('hydrates fingerprint from legacy array shape via AlertPayload::from', function () {
     $generator = new AlertFingerprintGenerator();
 
-    $degraded = ['severity' => 'warning'];  // no tenant_code, no type
+    $legacyArray = [
+        'tenant_code' => 'rostan',
+        'tenant_name' => 'ROSTAN Abidjan',
+        'type' => 'ssl_expiring',
+        'severity' => 'critical',
+        'message' => 'SSL expire dans 3 jours',
+    ];
 
-    $fp = $generator->generate(1, $degraded);
-    expect($fp)->toBeString();
-    expect(strlen($fp))->toBe(64);  // sha256 hex
+    $payload = AlertPayload::from($legacyArray);
+    $direct = makePayload('rostan', AlertType::SslExpiring, AlertSeverity::Critical);
+
+    expect($generator->generate(1, $payload))->toBe($generator->generate(1, $direct));
 });

--- a/tests/Unit/Support/Alerts/AlertPayloadTest.php
+++ b/tests/Unit/Support/Alerts/AlertPayloadTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertType;
+use App\Models\Tenant;
+use App\Support\Alerts\AlertPayload;
+
+it('constructs from a Tenant via make()', function () {
+    $tenant = new Tenant(['code' => 'rostan', 'name' => 'ROSTAN Abidjan']);
+
+    $payload = AlertPayload::make(
+        $tenant,
+        AlertSeverity::Critical,
+        AlertType::QuotaExceeded,
+        'Quota users dépassé (105%)',
+    );
+
+    expect($payload->severity)->toBe(AlertSeverity::Critical)
+        ->and($payload->type)->toBe(AlertType::QuotaExceeded)
+        ->and($payload->tenantCode)->toBe('rostan')
+        ->and($payload->tenantName)->toBe('ROSTAN Abidjan')
+        ->and($payload->message)->toBe('Quota users dépassé (105%)');
+});
+
+it('hydrates from a legacy array via from()', function () {
+    $legacy = [
+        'severity' => 'warning',
+        'type' => 'ssl_expiring',
+        'tenant_code' => 'yakro',
+        'tenant_name' => 'ESBTP Yakro',
+        'message' => 'Certificat expire dans 10 jours',
+    ];
+
+    $payload = AlertPayload::from($legacy);
+
+    expect($payload->severity)->toBe(AlertSeverity::Warning)
+        ->and($payload->type)->toBe(AlertType::SslExpiring)
+        ->and($payload->tenantCode)->toBe('yakro')
+        ->and($payload->tenantName)->toBe('ESBTP Yakro')
+        ->and($payload->message)->toBe('Certificat expire dans 10 jours');
+});
+
+it('returns the same instance when from() receives an AlertPayload (fast path)', function () {
+    $tenant = new Tenant(['code' => 'rostan', 'name' => 'ROSTAN']);
+    $original = AlertPayload::make($tenant, AlertSeverity::Info, AlertType::SubscriptionExpiring, 'hi');
+
+    expect(AlertPayload::from($original))->toBe($original);
+});
+
+it('round-trips through toArray and from()', function () {
+    $tenant = new Tenant(['code' => 'rostan', 'name' => 'ROSTAN']);
+    $original = AlertPayload::make(
+        $tenant,
+        AlertSeverity::Critical,
+        AlertType::UnpaidInvoices,
+        '4.6M FCFA impayés depuis >60 jours',
+    );
+
+    $roundTrip = AlertPayload::from($original->toArray());
+
+    expect($roundTrip->severity)->toBe($original->severity)
+        ->and($roundTrip->type)->toBe($original->type)
+        ->and($roundTrip->tenantCode)->toBe($original->tenantCode)
+        ->and($roundTrip->tenantName)->toBe($original->tenantName)
+        ->and($roundTrip->message)->toBe($original->message);
+});
+
+it('falls back to tenant_code when tenant_name is absent in legacy array', function () {
+    $payload = AlertPayload::from([
+        'severity' => 'info',
+        'type' => 'subscription_expiring',
+        'tenant_code' => 'rostan',
+        'message' => 'expire dans 20j',
+    ]);
+
+    expect($payload->tenantName)->toBe('rostan')
+        ->and($payload->tenantCode)->toBe('rostan');
+});
+
+it('survives Laravel cache serialization (readonly + enum properties)', function () {
+    $tenant = new Tenant(['code' => 'rostan', 'name' => 'ROSTAN']);
+    $original = AlertPayload::make($tenant, AlertSeverity::Critical, AlertType::QuotaCritical, 'msg');
+
+    $serialized = serialize($original);
+    $restored = unserialize($serialized);
+
+    expect($restored)->toBeInstanceOf(AlertPayload::class)
+        ->and($restored->severity)->toBe(AlertSeverity::Critical)
+        ->and($restored->type)->toBe(AlertType::QuotaCritical);
+});


### PR DESCRIPTION
Closes #46

## Summary

Remplace l'array ad-hoc `$alert` passé entre TenantAggregationService, AlertFingerprintGenerator, AlertRoleMatcher, AlertNotificationDispatcher, GroupAlertNotificationLog et les Mailables par un readonly DTO typé `App\Support\Alerts\AlertPayload`.

Élimine 5+ null-coalesces `?? 'unknown'`/`?? ''` qui masquaient la drift de shape entre producteur et consommateurs. Types enum (AlertType, AlertSeverity) garantissent la présence à la construction.

## Migration strategy

- `AlertPayload::from()` accepte AlertPayload|array : hydrate la donnée cachée au format legacy pendant que le TTL (5 min) se flush après deploy — **zero rollback pain**
- `buildAlert()` dans TenantAggregationService retourne désormais AlertPayload au lieu d'array — 9 callsites migrent via ce helper unique sans toucher les collectXxxAlerts
- Consommateurs type-hint AlertPayload : AlertFingerprintGenerator, AlertNotificationDispatcher, CriticalAlertMail, DailyAlertDigestMail
- Blade mail templates (critical-alert, daily-digest) lisent `$alert->message` au lieu de `$alert['message']`
- AlertsIndex page + GroupAlertsWidget hydratent via `AlertPayload::from()` puis enrichissent en array (fingerprint, acknowledged) pour compat template Alpine

## Tests

| Test | Status |
|------|--------|
| AlertPayload construction + hydratation + roundtrip + serialization | ✅ 6 new |
| AlertFingerprintGenerator migrated to AlertPayload | ✅ 5 migrated |
| Full group suite | ✅ 274 passed / 771 assertions / 1 skipped |
| Visual check /groupe + /groupe/alertes | ✅ PASS (urgent tier induced, banner + widget + page + sidebar badge all rendering correctly with DTO) |

## Quality Gate 4 axes

| Axe | Verdict |
|-----|---------|
| Architecture | PASS — DTO single source of truth, `buildAlert()` helper unchanged |
| Qualité vs Vitesse | PASS — 6 new unit tests + migrated fingerprint test + full regression suite |
| Production-grade | PASS — cache-compat via `AlertPayload::from()`, no feature flag needed (graceful migration) |
| SOLID | PASS — readonly DTO + enum types (ISP+OCP), dispatcher/fingerprint/mailable type-hinted |

Session: plan-and-confirm 2026-04-22 (Phase 2 of 3).

## Type

refactor