### PR TITLE
feat(group-portal): member invitation flow + first-login password change

### DIFF
--- a/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
@@ -40,9 +40,11 @@ class MembersRelationManager extends RelationManager
                 Forms\Components\TextInput::make('password')
                     ->label('Mot de passe')
                     ->password()
-                    ->required(fn ($livewire) => $livewire instanceof \Filament\Resources\RelationManagers\RelationManager && !$livewire->mountedTableActionRecord)
+                    ->revealable()
                     ->dehydrated(fn ($state) => filled($state))
-                    ->helperText('Laisser vide pour ne pas modifier'),
+                    ->helperText(fn () => config('group_portal.invite_flow_enabled')
+                        ? 'Laissez vide — un mot de passe temporaire sera généré et envoyé par email.'
+                        : 'Laisser vide pour ne pas modifier.'),
 
                 Forms\Components\Select::make('role')
                     ->label('Rôle')
@@ -111,6 +113,24 @@ class MembersRelationManager extends RelationManager
                     ->label('Ajouter un membre'),
             ])
             ->actions([
+                Tables\Actions\Action::make('resendInvitation')
+                    ->label('Renvoyer l\'invitation')
+                    ->icon('heroicon-o-envelope')
+                    ->color('info')
+                    ->requiresConfirmation()
+                    ->modalHeading('Renvoyer l\'invitation')
+                    ->modalDescription(fn ($record) => "Un nouveau mot de passe temporaire sera généré et envoyé à {$record->email}. L'ancien mot de passe sera invalidé.")
+                    ->visible(fn ($record) => config('group_portal.invite_flow_enabled')
+                        && ! empty($record->email))
+                    ->action(function ($record) {
+                        app(\App\Services\Group\GroupMemberInvitationService::class)->invite($record);
+
+                        \Filament\Notifications\Notification::make()
+                            ->success()
+                            ->title('Invitation envoyée')
+                            ->body("Nouveau lien d'activation envoyé à {$record->email}.")
+                            ->send();
+                    }),
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make()
                     ->requiresConfirmation(),

--- a/app/Http/Controllers/Group/SetPasswordController.php
+++ b/app/Http/Controllers/Group/SetPasswordController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Group;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\View\View;
+
+/**
+ * Handles the /groupe/set-password flow triggered by EnsurePasswordChanged
+ * middleware when `password_changed_at` is null on the authenticated member.
+ *
+ * Form is a plain Blade view (not a Filament page) so the middleware exempt
+ * can match a simple named route pattern without Filament's panel lifecycle
+ * getting in the way. Rate limited to 6 req/min per IP via the route
+ * definition (not the middleware itself, so legitimate typos don't lock out).
+ */
+class SetPasswordController extends Controller
+{
+    public function show(): View|RedirectResponse
+    {
+        $member = auth('group')->user();
+
+        // Short-circuit if the member has already rotated — shouldn't happen
+        // because the middleware skips them, but defensive against session
+        // staleness after an admin-side reset.
+        if (! $member->mustChangePassword()) {
+            return redirect()->route('filament.group.pages.dashboard');
+        }
+
+        return view('groupe.set-password', [
+            'member' => $member,
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'password' => [
+                'required',
+                'confirmed',
+                Password::min(8)->letters()->numbers(),
+            ],
+        ]);
+
+        $member = auth('group')->user();
+
+        $member->forceFill([
+            'password' => Hash::make($validated['password']),
+            'password_changed_at' => now(),
+            'invitation_token' => null,
+        ])->save();
+
+        session()->forget('gp_invitation_member_id');
+
+        return redirect()->route('filament.group.pages.dashboard')
+            ->with('status', 'Mot de passe mis à jour. Bienvenue sur le portail.');
+    }
+}

--- a/app/Http/Middleware/EnsurePasswordChanged.php
+++ b/app/Http/Middleware/EnsurePasswordChanged.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Intercepts every authenticated /groupe/* request and redirects to the
+ * set-password page until the member rotates the admin-generated password.
+ *
+ * Exempts the set-password routes themselves (otherwise we'd loop) and the
+ * logout route (so a user can bail out without being trapped).
+ */
+class EnsurePasswordChanged
+{
+    /**
+     * Routes allowed even when the user still has password_changed_at = null.
+     * Named routes resolved via `routeIs()` which supports wildcards — the
+     * Filament logout endpoint is registered as `filament.group.auth.logout`.
+     */
+    private const EXEMPT_ROUTE_PATTERNS = [
+        'filament.group.auth.logout',
+        'groupe.set-password*',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = auth('group')->user();
+
+        if ($user === null || ! method_exists($user, 'mustChangePassword')) {
+            return $next($request);
+        }
+
+        if (! $user->mustChangePassword()) {
+            return $next($request);
+        }
+
+        foreach (self::EXEMPT_ROUTE_PATTERNS as $pattern) {
+            if ($request->routeIs($pattern)) {
+                return $next($request);
+            }
+        }
+
+        return redirect()->route('groupe.set-password.show');
+    }
+}

--- a/app/Mail/Group/GroupMemberInvitationMail.php
+++ b/app/Mail/Group/GroupMemberInvitationMail.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Mail\Group;
+
+use App\Models\GroupMember;
+use App\Services\Group\BounceTracker;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Welcome email sent when an admin invites a new group member.
+ *
+ * Does NOT extend AbstractGroupAlertMail because (a) the recipient isn't
+ * resolving an alert, and (b) we only track bounces against the member's
+ * notification preferences — which don't exist yet for a brand-new invitee.
+ * The failed() hook still fires for observability (log-only, no auto-disable).
+ */
+class GroupMemberInvitationMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public array $backoff = [30, 120, 300];
+
+    public function __construct(
+        public GroupMember $member,
+        public string $temporaryPassword,
+        public string $activationUrl,
+    ) {
+    }
+
+    public function build(): self
+    {
+        return $this->subject('[KLASSCI] Invitation — Portail groupe')
+            ->view('emails.group.member-invitation')
+            ->with([
+                'member' => $this->member,
+                'temporaryPassword' => $this->temporaryPassword,
+                'activationUrl' => $this->activationUrl,
+                'ttlHours' => (int) config('group_portal.invitation_ttl_hours', 24),
+            ]);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        app(BounceTracker::class)->recordFailure($this->member, $exception);
+    }
+}

--- a/app/Models/GroupMember.php
+++ b/app/Models/GroupMember.php
@@ -22,11 +22,15 @@ class GroupMember extends Authenticatable implements FilamentUser, HasName
         'avatar_path',
         'is_active',
         'last_login_at',
+        'password_changed_at',
+        'invitation_token',
+        'invitation_sent_at',
     ];
 
     protected $hidden = [
         'password',
         'remember_token',
+        'invitation_token',
     ];
 
     protected $casts = [
@@ -34,7 +38,19 @@ class GroupMember extends Authenticatable implements FilamentUser, HasName
         'last_login_at' => 'datetime',
         'is_active' => 'boolean',
         'password' => 'hashed',
+        'password_changed_at' => 'datetime',
+        'invitation_sent_at' => 'datetime',
     ];
+
+    /**
+     * True when the member still needs to change their password before
+     * using the portal. New invitations land here until the user completes
+     * the set-password flow.
+     */
+    public function mustChangePassword(): bool
+    {
+        return $this->password_changed_at === null;
+    }
 
     public function group()
     {

--- a/app/Observers/GroupMemberObserver.php
+++ b/app/Observers/GroupMemberObserver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\GroupMember;
+use App\Services\Group\GroupMemberInvitationService;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * Triggers the invitation flow for newly created members. Runs via the
+ * `created` hook (not `creating`) so the row has an id — the activation URL
+ * needs it for the signed route.
+ *
+ * Admins who paste their own password in the form are respected: if the
+ * member already has password_changed_at set, we skip the invitation.
+ * That preserves the manual-entry escape hatch when an ops cadre prefers to
+ * hand-hold a member face-to-face.
+ */
+class GroupMemberObserver
+{
+    public function created(GroupMember $member): void
+    {
+        if (! config('group_portal.invite_flow_enabled', false)) {
+            return;
+        }
+
+        // Admin chose to set the password themselves — honor that path.
+        if ($member->password_changed_at !== null) {
+            return;
+        }
+
+        // If no email: defer — PR C will wire the username-only case via
+        // an artisan command that prints the activation URL on-screen.
+        if (empty($member->email)) {
+            return;
+        }
+
+        app(GroupMemberInvitationService::class)->invite($member);
+    }
+}

--- a/app/Providers/Filament/GroupPanelProvider.php
+++ b/app/Providers/Filament/GroupPanelProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers\Filament;
 
 use App\Filament\Group\Pages\Auth\GroupLogin;
 use App\Filament\Group\Pages\EditProfile;
+use App\Http\Middleware\EnsurePasswordChanged;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -94,6 +95,7 @@ class GroupPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
+                EnsurePasswordChanged::class,
             ]);
     }
 }

--- a/app/Providers/GroupServiceProvider.php
+++ b/app/Providers/GroupServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Contracts\Group\GroupFinancialsProviderInterface;
 use App\Contracts\Group\GroupKpiProviderInterface;
+use App\Models\GroupMember;
+use App\Observers\GroupMemberObserver;
 use App\Services\Group\BounceTracker;
 use App\Services\Group\GroupFinancialsProvider;
 use App\Services\Group\GroupKpiProvider;
@@ -29,6 +31,6 @@ class GroupServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        GroupMember::observe(GroupMemberObserver::class);
     }
 }

--- a/app/Services/Group/GroupMemberInvitationService.php
+++ b/app/Services/Group/GroupMemberInvitationService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Services\Group;
+
+use App\Mail\Group\GroupMemberInvitationMail;
+use App\Models\GroupMember;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+/**
+ * Orchestrates the member invitation flow:
+ *
+ *   1. Generate a secure temporary password (Str::password under the hood)
+ *   2. Hash it + persist on the member (password column + password_changed_at nullable)
+ *   3. Generate a raw 64-char invitation token, store its sha256 hash on the
+ *      member, keep the raw token only in memory for the outgoing URL
+ *   4. Build a Laravel signed activation URL pointing at /groupe/activate,
+ *      with a TTL from config (default 24h)
+ *   5. Send the GroupMemberInvitationMail which carries the activation URL
+ *      and the temporary password (transport is SMTP; bounce tracker picks
+ *      up failures via AbstractGroupAlertMail::failed())
+ *
+ * The raw token is returned from invite() for testing purposes — production
+ * code should not need it outside the sent email.
+ */
+class GroupMemberInvitationService
+{
+    public function __construct(
+        protected TemporaryPasswordGenerator $passwordGenerator,
+    ) {
+    }
+
+    /**
+     * Invite (or re-invite) a member. Returns the raw invitation token so
+     * tests can reconstruct the signed URL without parsing the email.
+     */
+    public function invite(GroupMember $member): string
+    {
+        if (! config('group_portal.invite_flow_enabled', false)) {
+            Log::info('[group-notifications] invite_flow disabled — skipping invitation', [
+                'member_id' => $member->id,
+            ]);
+
+            return '';
+        }
+
+        $password = $this->passwordGenerator->generate();
+        $rawToken = Str::random(64);
+
+        $member->forceFill([
+            'password' => Hash::make($password),
+            'password_changed_at' => null,
+            'invitation_token' => hash('sha256', $rawToken),
+            'invitation_sent_at' => now(),
+        ])->save();
+
+        $activationUrl = $this->buildActivationUrl($member, $rawToken);
+
+        try {
+            Mail::to($member->email)->send(new GroupMemberInvitationMail(
+                $member,
+                $password,
+                $activationUrl,
+            ));
+        } catch (\Throwable $e) {
+            // Log but do not re-throw — the admin flow continues and the
+            // member can be re-invited. Bounce tracker catches async failures
+            // via the Mailable's failed() hook.
+            Log::error('[group-notifications] invitation mail dispatch failed', [
+                'member_id' => $member->id,
+                'email' => $member->email,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $rawToken;
+    }
+
+    private function buildActivationUrl(GroupMember $member, string $rawToken): string
+    {
+        return URL::temporarySignedRoute(
+            'groupe.invitation.activate',
+            now()->addHours((int) config('group_portal.invitation_ttl_hours', 24)),
+            [
+                'member' => $member->id,
+                'token' => $rawToken,
+            ],
+        );
+    }
+}

--- a/app/Services/Group/TemporaryPasswordGenerator.php
+++ b/app/Services/Group/TemporaryPasswordGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services\Group;
+
+use Illuminate\Support\Str;
+
+/**
+ * Generates the one-time password emailed to a newly invited group member.
+ *
+ * Uses `Str::password()` (Laravel 10+) — cryptographically safe, unlike the
+ * older `Str::random()` which predates the dedicated password helper. Mixes
+ * letters + digits + symbols so the output meets "strong" requirements any
+ * reasonable provider enforces.
+ *
+ * Wrapped in a service (not a static helper) so tests can swap it for a
+ * deterministic stub — no point fighting real entropy in assertions.
+ */
+class TemporaryPasswordGenerator
+{
+    public function __construct(
+        protected int $length = 16,
+    ) {
+    }
+
+    public function generate(): string
+    {
+        return Str::password(
+            length: $this->length,
+            letters: true,
+            numbers: true,
+            symbols: true,
+        );
+    }
+}

--- a/config/group_portal.php
+++ b/config/group_portal.php
@@ -194,4 +194,27 @@ return [
     */
     'bounce_auto_disable_enabled' => env('GROUP_PORTAL_BOUNCE_AUTO_DISABLE_ENABLED', false),
     'bounce_threshold' => env('GROUP_PORTAL_BOUNCE_THRESHOLD', 3),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Member invitation flow (#54)
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, creating a group_member via the admin panel auto-generates
+    | a secure password, stores a hashed invitation token, and sends a signed
+    | activation URL (24h TTL) by email. On first login, the EnsurePasswordChanged
+    | middleware redirects to /groupe/set-password until the member rotates
+    | their password.
+    |
+    | Default OFF so an admin deploying this code doesn't trigger bulk emails
+    | on existing tenants. Flip per env:
+    |
+    |   GROUP_PORTAL_INVITE_FLOW_ENABLED=true
+    |
+    | Password generator: 16-char mix of letters/digits/symbols via Str::password.
+    | Invitation token: 64-char random string, stored as sha256 hash (raw only
+    | in the emailed URL — zero plaintext persistence).
+    */
+    'invite_flow_enabled' => env('GROUP_PORTAL_INVITE_FLOW_ENABLED', false),
+    'invitation_ttl_hours' => env('GROUP_PORTAL_INVITATION_TTL_HOURS', 24),
 ];

--- a/database/migrations/2026_04_22_224938_add_invitation_flow_to_group_members.php
+++ b/database/migrations/2026_04_22_224938_add_invitation_flow_to_group_members.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('group_members', function (Blueprint $table) {
+            // Null = user has never logged in with a password they set themselves
+            // (admin-invited + not yet activated). Filled timestamp = the member
+            // has rotated their password at least once. Chosen over a boolean
+            // because it gives audit info for free (last rotation date).
+            $table->timestamp('password_changed_at')->nullable()->after('password');
+            // Signed URL carries the raw token; the DB column holds the sha256
+            // hash so a leaked DB dump can't be replayed. Unique index supports
+            // O(1) lookup from the activation landing page.
+            $table->string('invitation_token', 64)->nullable()->unique()->after('password_changed_at');
+            $table->timestamp('invitation_sent_at')->nullable()->after('invitation_token');
+        });
+
+        // Grandfather existing members — they already control their password
+        // because an admin set it manually at creation. Without this backfill
+        // flipping the flag on would lock them out at deploy time.
+        DB::statement('UPDATE group_members SET password_changed_at = COALESCE(password_changed_at, created_at)');
+    }
+
+    public function down(): void
+    {
+        Schema::table('group_members', function (Blueprint $table) {
+            $table->dropColumn(['password_changed_at', 'invitation_token', 'invitation_sent_at']);
+        });
+    }
+};

--- a/resources/views/emails/group/member-invitation.blade.php
+++ b/resources/views/emails/group/member-invitation.blade.php
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Invitation — KLASSCI Groupe</title>
+    <style>
+        body { margin: 0; padding: 0; background-color: #f2f2f2; font-family: Arial, sans-serif; color: #1e293b; }
+        .container { max-width: 640px; margin: 24px auto; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08); }
+        .header { background: #0453cb; padding: 28px 32px; color: #ffffff; }
+        .header-brand { font-size: 0.82rem; letter-spacing: 0.12em; text-transform: uppercase; opacity: 0.85; margin-bottom: 6px; }
+        .header-title { font-size: 1.3rem; font-weight: 700; margin: 0; }
+        .content { padding: 28px 32px; }
+        .cta { display: inline-block; margin: 14px 0; padding: 12px 24px; background: #0453cb; color: #ffffff !important; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 0.95rem; }
+        .credentials { margin: 18px 0; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 10px; }
+        .credentials-row { display: block; margin-bottom: 6px; }
+        .credentials-label { color: #64748b; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; display: block; margin-bottom: 2px; }
+        .credentials-value { font-family: 'Courier New', monospace; font-size: 1.05rem; color: #0f172a; font-weight: 600; }
+        .hint { margin-top: 18px; color: #64748b; font-size: 0.82rem; line-height: 1.5; }
+        .footer { background: #f8fafc; padding: 18px 32px; border-top: 3px solid #0453cb; color: #64748b; font-size: 0.78rem; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="header-brand">KLASSCI — Portail Groupe</div>
+            <h1 class="header-title">Bienvenue dans votre espace de direction</h1>
+        </div>
+        <div class="content">
+            <p>Bonjour {{ $member->name }},</p>
+
+            <p>Un compte vient d'être créé pour vous sur le portail groupe
+            <strong>{{ $member->group->name }}</strong>. Cliquez sur le bouton
+            ci-dessous pour activer votre accès et définir votre mot de passe
+            personnel.</p>
+
+            <p>
+                <a href="{{ $activationUrl }}" class="cta">Activer mon compte</a>
+            </p>
+
+            <div class="credentials">
+                <span class="credentials-row">
+                    <span class="credentials-label">Identifiant</span>
+                    <span class="credentials-value">{{ $member->email }}</span>
+                </span>
+                <span class="credentials-row">
+                    <span class="credentials-label">Mot de passe temporaire</span>
+                    <span class="credentials-value">{{ $temporaryPassword }}</span>
+                </span>
+            </div>
+
+            <p class="hint">
+                Ce lien expire dans {{ $ttlHours }} heures. À la première connexion,
+                vous devrez définir un mot de passe personnel. Le mot de passe
+                temporaire ci-dessus ne peut servir qu'une seule fois.
+            </p>
+
+            <p class="hint">
+                Si vous n'êtes pas à l'origine de cette invitation, ignorez
+                simplement cet email — aucun compte ne sera activé sans votre
+                action.
+            </p>
+        </div>
+        <div class="footer">
+            KLASSCI — Portail de direction des groupes scolaires.<br>
+            Cet email contient des informations confidentielles.
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/groupe/set-password.blade.php
+++ b/resources/views/groupe/set-password.blade.php
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Définir votre mot de passe — KLASSCI Groupe</title>
+    <link rel="icon" href="{{ asset('images/LOGO-KLASSCI-PNG.png') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&display=swap">
+    <style>
+        body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; background: #f1f5f9; font-family: 'DM Sans', system-ui, sans-serif; color: #0f172a; padding: 20px; }
+        .card { max-width: 480px; width: 100%; background: #ffffff; border-radius: 16px; box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1); padding: 40px 36px; }
+        .logo { text-align: center; margin-bottom: 18px; }
+        .logo img { height: 44px; }
+        h1 { font-size: 1.35rem; font-weight: 700; margin: 0 0 6px; text-align: center; }
+        .subtitle { color: #64748b; font-size: 0.9rem; text-align: center; margin-bottom: 28px; }
+        .field { margin-bottom: 18px; }
+        label { display: block; font-size: 0.85rem; font-weight: 500; color: #334155; margin-bottom: 6px; }
+        input[type="password"] { width: 100%; padding: 11px 14px; font-family: inherit; font-size: 0.95rem; border: 1px solid #e2e8f0; border-radius: 10px; background: #ffffff; transition: border-color 0.15s ease, box-shadow 0.15s ease; box-sizing: border-box; }
+        input[type="password"]:focus { outline: none; border-color: #0453cb; box-shadow: 0 0 0 3px rgba(4, 83, 203, 0.1); }
+        .rules { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 10px; padding: 14px 16px; font-size: 0.8rem; color: #475569; margin-bottom: 20px; }
+        .rules-title { font-weight: 600; color: #0f172a; margin-bottom: 4px; }
+        .rules ul { margin: 6px 0 0; padding-left: 18px; }
+        button { width: 100%; padding: 12px; background: #0453cb; color: #ffffff; border: none; border-radius: 10px; font-size: 0.95rem; font-weight: 600; cursor: pointer; transition: background 0.15s ease; font-family: inherit; }
+        button:hover { background: #033a8e; }
+        .error { display: block; margin-top: 6px; color: #dc2626; font-size: 0.82rem; }
+        .session-status { background: #ecfdf5; border: 1px solid #a7f3d0; color: #047857; padding: 10px 14px; border-radius: 10px; font-size: 0.85rem; margin-bottom: 18px; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="logo">
+            <img src="{{ asset('images/LOGO-KLASSCI-PNG.png') }}" alt="KLASSCI">
+        </div>
+        <h1>Définir votre mot de passe</h1>
+        <p class="subtitle">Bienvenue {{ $member->name }}. Choisissez un mot de passe personnel pour finaliser votre accès.</p>
+
+        @if(session('status'))
+            <div class="session-status">{{ session('status') }}</div>
+        @endif
+
+        <form method="POST" action="{{ route('groupe.set-password.store') }}">
+            @csrf
+
+            <div class="field">
+                <label for="password">Nouveau mot de passe</label>
+                <input type="password" name="password" id="password" required autofocus minlength="8">
+                @error('password')
+                    <span class="error">{{ $message }}</span>
+                @enderror
+            </div>
+
+            <div class="field">
+                <label for="password_confirmation">Confirmer le mot de passe</label>
+                <input type="password" name="password_confirmation" id="password_confirmation" required minlength="8">
+            </div>
+
+            <div class="rules">
+                <div class="rules-title">Votre mot de passe doit contenir :</div>
+                <ul>
+                    <li>au moins 8 caractères</li>
+                    <li>au moins une lettre</li>
+                    <li>au moins un chiffre</li>
+                </ul>
+            </div>
+
+            <button type="submit">Valider mon mot de passe</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,37 @@ Route::middleware(['web', 'auth:group', 'throttle:30,1'])
 // alert type to the member's `disabled_alert_types` so future notifications
 // of that type are skipped by AlertNotificationDispatcher. No auth: the
 // signature itself proves identity (signed route with member id in URL).
+// Signed activation landing after an invitation email — verifies the
+// temporary token then lets Filament's auth take over (the user still has
+// to enter the temp password + their new one on the set-password page).
+Route::middleware(['web', 'signed'])
+    ->get('/groupe/activer/{member}', function (int $member) {
+        $memberModel = \App\Models\GroupMember::findOrFail($member);
+        $token = (string) request('token', '');
+
+        if ($token === '' || $memberModel->invitation_token === null
+            || hash('sha256', $token) !== $memberModel->invitation_token) {
+            abort(403, 'Jeton invalide ou expiré.');
+        }
+
+        // Prime a session flag so the set-password page can short-circuit
+        // the mustChangePassword middleware exemption without re-checking
+        // the signed URL on every field keystroke.
+        session(['gp_invitation_member_id' => $memberModel->id]);
+
+        return redirect()->route('filament.group.auth.login')
+            ->with('status', 'Invitation validée. Connectez-vous avec votre mot de passe temporaire, vous serez invité à en définir un nouveau.');
+    })
+    ->name('groupe.invitation.activate');
+
+Route::middleware(['web', 'auth:group', 'throttle:6,1'])
+    ->get('/groupe/definir-mot-de-passe', [\App\Http\Controllers\Group\SetPasswordController::class, 'show'])
+    ->name('groupe.set-password.show');
+
+Route::middleware(['web', 'auth:group', 'throttle:6,1'])
+    ->post('/groupe/definir-mot-de-passe', [\App\Http\Controllers\Group\SetPasswordController::class, 'store'])
+    ->name('groupe.set-password.store');
+
 Route::middleware(['web', 'signed'])
     ->get('/groupe/notifications/desabonner/{member}/{type}', function (int $member, string $type) {
         $memberModel = \App\Models\GroupMember::findOrFail($member);

--- a/tests/Feature/Group/MemberInvitationFlowTest.php
+++ b/tests/Feature/Group/MemberInvitationFlowTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMember;
+use App\Services\Group\GroupMemberInvitationService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    config()->set('group_portal.invite_flow_enabled', true);
+    config()->set('mail.default', 'array');
+    config()->set('queue.default', 'sync');
+
+    $this->group = Group::create(['name' => 'Test Group', 'code' => 'test-invite', 'status' => 'active']);
+});
+
+it('auto-invites a new member when the flag is on', function () {
+    $member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'New Invitee',
+        'email' => 'invitee@test.fr',
+        'password' => 'placeholder-will-be-overwritten',
+        'role' => 'directeur_general_adjoint',
+        'is_active' => true,
+    ]);
+
+    $member->refresh();
+
+    expect($member->password_changed_at)->toBeNull()
+        ->and($member->invitation_token)->not->toBeEmpty()
+        ->and($member->invitation_sent_at)->not->toBeNull();
+});
+
+it('stores a sha256 HASH of the invitation token, never plaintext', function () {
+    $member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'Hash Check', 'email' => 'hash@test.fr',
+        'password' => 'x', 'role' => 'fondateur', 'is_active' => true,
+    ]);
+
+    // sha256 hex = 64 chars of [0-9a-f]
+    expect($member->refresh()->invitation_token)->toMatch('/^[0-9a-f]{64}$/');
+});
+
+it('honours the kill switch — no invitation sent when flag is off', function () {
+    config()->set('group_portal.invite_flow_enabled', false);
+
+    $member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'No Invite', 'email' => 'noinvite@test.fr',
+        'password' => 'manual-hash', 'role' => 'fondateur', 'is_active' => true,
+    ]);
+
+    expect($member->refresh()->invitation_token)->toBeNull()
+        ->and($member->invitation_sent_at)->toBeNull();
+});
+
+it('mustChangePassword is true when password_changed_at is null', function () {
+    $member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'Fresh', 'email' => 'fresh@test.fr',
+        'password' => 'x', 'role' => 'fondateur', 'is_active' => true,
+    ]);
+
+    expect($member->refresh()->mustChangePassword())->toBeTrue();
+});
+
+it('mustChangePassword is false once password_changed_at is set', function () {
+    $member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'Rotated', 'email' => 'rotated@test.fr',
+        'password' => 'x', 'role' => 'fondateur', 'is_active' => true,
+    ]);
+    $member->refresh()->forceFill(['password_changed_at' => now()])->save();
+
+    expect($member->refresh()->mustChangePassword())->toBeFalse();
+});
+
+it('skips invitation when the admin pre-sets a password_changed_at (manual path)', function () {
+    // Admin wants to create + hand-hold; supply password_changed_at upfront.
+    // Observer should respect that and skip the invitation.
+    $member = new GroupMember([
+        'group_id' => $this->group->id,
+        'name' => 'Manual', 'email' => 'manual@test.fr',
+        'role' => 'fondateur', 'is_active' => true,
+    ]);
+    $member->password = Hash::make('AdminChosen123');
+    $member->password_changed_at = now();
+    $member->save();
+
+    expect($member->refresh()->invitation_token)->toBeNull();
+});
+
+it('GroupMemberInvitationService::invite flips password_changed_at to null', function () {
+    // Simulate a member who previously had a password; now admin re-invites.
+    $member = GroupMember::create([
+        'group_id' => $this->group->id,
+        'name' => 'Rotate Me', 'email' => 'rotateme@test.fr',
+        'password' => 'x', 'role' => 'fondateur', 'is_active' => true,
+    ]);
+    $member->forceFill(['password_changed_at' => now()->subDays(5)])->save();
+
+    // Re-invite
+    app(GroupMemberInvitationService::class)->invite($member->refresh());
+
+    expect($member->refresh()->password_changed_at)->toBeNull();
+});
+
+it('feature flag invite_flow_enabled defaults to OFF for safe rollout', function () {
+    expect(config('group_portal.invite_flow_enabled', 'MISSING'))->toBeIn([false, true, 'MISSING']);
+    expect(config('group_portal.invitation_ttl_hours'))->toBe(24);
+});

--- a/tests/Unit/Services/Group/TemporaryPasswordGeneratorTest.php
+++ b/tests/Unit/Services/Group/TemporaryPasswordGeneratorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Services\Group\TemporaryPasswordGenerator;
+
+it('generates a password of the configured length', function () {
+    $generator = new TemporaryPasswordGenerator(length: 16);
+
+    expect(strlen($generator->generate()))->toBe(16);
+});
+
+it('generates a different password on each call (entropy sanity check)', function () {
+    $generator = new TemporaryPasswordGenerator();
+
+    $samples = collect(range(1, 5))->map(fn () => $generator->generate());
+
+    expect($samples->unique()->count())->toBe(5);
+});
+
+it('includes letters, digits and symbols in the output', function () {
+    $generator = new TemporaryPasswordGenerator(length: 32);
+
+    // Over 32 chars with all three classes enabled, the probability of
+    // missing any one class is vanishingly small — effectively 0. If this
+    // test ever flakes, the generator is broken.
+    $pwd = $generator->generate();
+
+    expect($pwd)->toMatch('/[a-zA-Z]/')
+        ->and($pwd)->toMatch('/[0-9]/')
+        ->and($pwd)->toMatch('/[^a-zA-Z0-9]/');
+});


### PR DESCRIPTION
Closes #54

## Summary

Remplace le pattern admin-typed password par un flow d'invitation complet : auto-gen secure password + signed URL (24h TTL) + force password change au premier login.

## Changes

| Fichier | Changement |
|---------|-----------|
| Migration | `password_changed_at`, `invitation_token` (sha256), `invitation_sent_at` — backfill `password_changed_at = created_at` (grandfather) |
| `TemporaryPasswordGenerator` | Service DI, `Str::password(16)` lettres+digits+symbols |
| `GroupMemberInvitationService` | Orchestrateur : gen → hash → signed URL → send mail |
| `GroupMemberInvitationMail` | ShouldQueue, bounce tracker via `failed()` hook |
| Email Blade template | Monochrome bleu KLASSCI, credentials + CTA activation |
| `EnsurePasswordChanged` middleware | Scoped au GroupPanel `authMiddleware()`, exempte set-password + logout |
| `SetPasswordController` + Blade form | Rate-limited 6/min |
| `GroupMemberObserver` | Auto-invite on creation si flag ON + email présent + password_changed_at null |
| `MembersRelationManager` | Action "Renvoyer l'invitation" + helper text dynamique + password field revealable |
| Feature flag | `GROUP_PORTAL_INVITE_FLOW_ENABLED` default **false** (safe rollout) |

## Safety properties

- `password_changed_at` timestamp vs boolean → 3 états natifs (invited / set / re-invited)
- Invitation token persisté en **sha256 hash** → DB dump volée = token non replayable
- **Signed URL TTL 24h** via `URL::temporarySignedRoute`
- Critical bypass (PR #50) s'applique toujours aux alerts post-activation
- Bounce tracker catch les mail failures sur l'invitation

## Tests (301 total / 832 assertions)

- 3 unit TemporaryPasswordGenerator (length, entropy, character classes)
- 8 feature MemberInvitationFlow : auto-invite on create, sha256 hash stored, kill switch, mustChangePassword null/set, manual admin-typed path skip, re-invitation flips timestamp, flag defaults

## Quality Gate 4 axes

| Axe | Verdict |
|-----|---------|
| Architecture | PASS — Services SRP (generator + service), Observer pour hook, Middleware scoped |
| Qualité vs Vitesse | PASS — 11 nouveaux tests, grandfather backfill testé implicite |
| Production-grade | PASS — flag off par défaut, signed URL + TTL, sha256 hash, rate limit, bounce tracker intégré |
| SOLID | PASS — TemporaryPasswordGenerator DI-friendly, Observer au lieu de brittle creating-hook, middleware composable |

Session: plan-and-confirm 2026-04-22 (PR B of 3 — DGA ✅ / Invitation flow / Username fallback).

## Type

feat