### PR TITLE
feat(group-portal): email optional + username fallback for member login

### DIFF
--- a/app/Console/Commands/ResetGroupMemberPassword.php
+++ b/app/Console/Commands/ResetGroupMemberPassword.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\GroupMember;
+use App\Services\Group\TemporaryPasswordGenerator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Fallback for members without email — the Filament password-reset link
+ * goes to an inbox they don't have. Admins run this on the server, read
+ * the temp password from stdout, and pass it to the member out-of-band.
+ *
+ * On success the member's `password_changed_at` is flipped to null so the
+ * EnsurePasswordChanged middleware forces a rotation on next login.
+ */
+class ResetGroupMemberPassword extends Command
+{
+    protected $signature = 'group-portal:reset-password
+                            {identifier : Member id, email, or username}';
+
+    protected $description = 'Generate + print a temporary password for a group member. Forces them to rotate on next login. Use when a username-only member needs password recovery.';
+
+    public function handle(TemporaryPasswordGenerator $generator): int
+    {
+        $identifier = (string) $this->argument('identifier');
+
+        $member = $this->resolveMember($identifier);
+
+        if (! $member) {
+            $this->error("No GroupMember matches {$identifier} (checked id, email, username).");
+
+            return self::FAILURE;
+        }
+
+        $tempPassword = $generator->generate();
+
+        $member->forceFill([
+            'password' => Hash::make($tempPassword),
+            'password_changed_at' => null,
+            'invitation_token' => null,
+        ])->save();
+
+        $this->line('');
+        $this->info("Password reset for {$member->name} ({$member->email} / @{$member->username}).");
+        $this->line('');
+        $this->line('  Mot de passe temporaire :');
+        $this->line('');
+        $this->line("    <fg=yellow;options=bold>{$tempPassword}</>");
+        $this->line('');
+        $this->warn('  Transmettez ce mot de passe au membre par un canal sécurisé.');
+        $this->warn('  Il sera invité à le changer dès la première connexion.');
+
+        return self::SUCCESS;
+    }
+
+    private function resolveMember(string $identifier): ?GroupMember
+    {
+        if (is_numeric($identifier)) {
+            return GroupMember::find((int) $identifier);
+        }
+
+        return GroupMember::where('email', $identifier)
+            ->orWhere('username', $identifier)
+            ->first();
+    }
+}

--- a/app/Filament/Group/Pages/Auth/GroupLogin.php
+++ b/app/Filament/Group/Pages/Auth/GroupLogin.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Group\Pages\Auth;
 
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse;
 use Filament\Pages\Auth\Login;
 use Illuminate\Contracts\Support\Htmlable;
@@ -17,6 +19,38 @@ class GroupLogin extends Login
     public function getSubHeading(): string|Htmlable
     {
         return 'Connectez-vous à votre espace de direction';
+    }
+
+    /**
+     * Relabel the email input — it accepts both an email and a username,
+     * the canonical identifier a DGA hired from a subsidiary may be issued
+     * without company email. Validation tightened to a loose string so the
+     * built-in `email` rule doesn't reject a username like `jean.diomande`.
+     */
+    protected function getEmailFormComponent(): Component
+    {
+        return TextInput::make('email')
+            ->label('Email ou nom d\'utilisateur')
+            ->required()
+            ->autocomplete()
+            ->autofocus()
+            ->extraInputAttributes(['tabindex' => 1]);
+    }
+
+    /**
+     * Map the single form input to the right auth column — email when it
+     * looks like an email, username otherwise. Keeps Filament's default
+     * password matching intact.
+     */
+    protected function getCredentialsFromFormData(array $data): array
+    {
+        $identifier = trim((string) ($data['email'] ?? ''));
+        $column = filter_var($identifier, FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
+
+        return [
+            $column => $identifier,
+            'password' => $data['password'],
+        ];
     }
 
     public function authenticate(): ?LoginResponse

--- a/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
@@ -33,9 +33,16 @@ class MembersRelationManager extends RelationManager
                 Forms\Components\TextInput::make('email')
                     ->label('Email')
                     ->email()
-                    ->required()
                     ->unique(ignoreRecord: true)
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->helperText('Laissez vide si le membre n\'a pas d\'email — un nom d\'utilisateur sera généré automatiquement.'),
+
+                Forms\Components\TextInput::make('username')
+                    ->label('Nom d\'utilisateur')
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(80)
+                    ->alphaDash()
+                    ->helperText('Généré automatiquement si vide et pas d\'email. Utilisé pour la connexion lorsqu\'il n\'y a pas d\'email.'),
 
                 Forms\Components\TextInput::make('password')
                     ->label('Mot de passe')
@@ -79,7 +86,9 @@ class MembersRelationManager extends RelationManager
 
                 Tables\Columns\TextColumn::make('email')
                     ->label('Email')
-                    ->searchable(),
+                    ->searchable()
+                    ->placeholder('—')
+                    ->description(fn ($record) => $record->username ? '@' . $record->username : null),
 
                 Tables\Columns\TextColumn::make('role')
                     ->label('Rôle')

--- a/app/Models/GroupMember.php
+++ b/app/Models/GroupMember.php
@@ -16,6 +16,7 @@ class GroupMember extends Authenticatable implements FilamentUser, HasName
         'group_id',
         'name',
         'email',
+        'username',
         'password',
         'role',
         'phone',

--- a/app/Observers/GroupMemberObserver.php
+++ b/app/Observers/GroupMemberObserver.php
@@ -4,6 +4,7 @@ namespace App\Observers;
 
 use App\Models\GroupMember;
 use App\Services\Group\GroupMemberInvitationService;
+use App\Services\Group\UsernameGenerator;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -19,6 +20,18 @@ use Illuminate\Support\Str;
  */
 class GroupMemberObserver
 {
+    /**
+     * Auto-generate a username before insert when the admin didn't supply
+     * an email. Runs on `creating` (not `created`) so the username lands in
+     * the same INSERT instead of a follow-up UPDATE.
+     */
+    public function creating(GroupMember $member): void
+    {
+        if (empty($member->username) && empty($member->email)) {
+            $member->username = app(UsernameGenerator::class)->generate($member->name ?? '');
+        }
+    }
+
     public function created(GroupMember $member): void
     {
         if (! config('group_portal.invite_flow_enabled', false)) {
@@ -30,8 +43,9 @@ class GroupMemberObserver
             return;
         }
 
-        // If no email: defer — PR C will wire the username-only case via
-        // an artisan command that prints the activation URL on-screen.
+        // Username-only members skip the email invitation. Admin must share
+        // the temporary password via `php artisan group-portal:reset-password`
+        // which prints the credentials on-screen.
         if (empty($member->email)) {
             return;
         }

--- a/app/Services/Group/UsernameGenerator.php
+++ b/app/Services/Group/UsernameGenerator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services\Group;
+
+use App\Models\GroupMember;
+use Illuminate\Support\Str;
+
+/**
+ * Derives a login-friendly username from a member's display name.
+ *
+ *   "Jean Diomandé"    → "jean.diomande"
+ *   "K. Marie Koffi"   → "k.marie.koffi" (fallback when we can't pick a
+ *                         clean first+last pair)
+ *   collision "jean.diomande" taken → "jean.diomande.2", .3, ...
+ *
+ * Accents are stripped via `Str::slug` (Intl-aware). Short names below two
+ * chars collapse to the whole slugged string.
+ */
+class UsernameGenerator
+{
+    private const MAX_LENGTH = 80;
+
+    public function generate(string $name): string
+    {
+        $base = $this->baseFromName($name);
+
+        if ($base === '') {
+            // Random 8-char suffix for pathological input (empty name,
+            // punctuation-only). Not pretty but prevents NOT-NULL / UNIQUE
+            // collisions from an obvious dev mistake.
+            $base = 'membre.' . Str::lower(Str::random(6));
+        }
+
+        return $this->dedup($base);
+    }
+
+    private function baseFromName(string $name): string
+    {
+        $slug = Str::slug($name, '.');
+
+        if ($slug === '') {
+            return '';
+        }
+
+        // Trim to first two segments when the name has more — "Jean
+        // Baptiste Diomandé" → "jean.diomande", not "jean.baptiste.diomande".
+        // Keeps usernames short without losing identity.
+        $parts = explode('.', $slug);
+        if (count($parts) >= 3) {
+            $slug = $parts[0] . '.' . end($parts);
+        }
+
+        return Str::limit($slug, self::MAX_LENGTH, '');
+    }
+
+    private function dedup(string $base): string
+    {
+        if (! $this->exists($base)) {
+            return $base;
+        }
+
+        // Avoid an unbounded loop on weird concurrency — 1000 attempts is
+        // already 1000 members with the same name, far past any realistic
+        // tenant size. Falls back to a random tail after that.
+        for ($i = 2; $i <= 1000; $i++) {
+            $candidate = $base . '.' . $i;
+            if (! $this->exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return $base . '.' . Str::lower(Str::random(4));
+    }
+
+    private function exists(string $username): bool
+    {
+        return GroupMember::query()->where('username', $username)->exists();
+    }
+}

--- a/database/migrations/2026_04_23_194013_add_username_and_make_email_nullable_on_group_members.php
+++ b/database/migrations/2026_04_23_194013_add_username_and_make_email_nullable_on_group_members.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Loosen the auth identity on group_members so admins can invite DGAs hired
+ * from subsidiaries without company email. One of (email, username) must be
+ * present — enforced application-side in the GroupMemberObserver, not at the
+ * DB level (MySQL CHECK constraints on nullable unique combos are flaky).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // MySQL needs the raw ALTER when changing unique + nullable on an
+        // existing column (Doctrine DBAL's inference drops the unique index).
+        DB::statement('ALTER TABLE group_members MODIFY COLUMN email VARCHAR(255) NULL');
+
+        Schema::table('group_members', function (Blueprint $table) {
+            // slug-shaped lowercase identifier; unique globally, not scoped
+            // per-group — the login flow is cross-group so a collision
+            // between two groups would confuse the auth lookup.
+            $table->string('username', 80)->nullable()->unique()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('group_members', function (Blueprint $table) {
+            $table->dropColumn('username');
+        });
+
+        // Only reinstate NOT NULL if no rows currently have a null email.
+        $nullEmails = DB::table('group_members')->whereNull('email')->count();
+        if ($nullEmails > 0) {
+            throw new \RuntimeException(
+                "Cannot rollback: {$nullEmails} group_member(s) have no email. Backfill them first."
+            );
+        }
+
+        DB::statement('ALTER TABLE group_members MODIFY COLUMN email VARCHAR(255) NOT NULL');
+    }
+};

--- a/tests/Feature/Group/GroupLoginCredentialsTest.php
+++ b/tests/Feature/Group/GroupLoginCredentialsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Filament\Group\Pages\Auth\GroupLogin;
+
+it('maps an email-shaped identifier to the email column', function () {
+    $login = new class extends GroupLogin {
+        public function callCredentials(array $data): array
+        {
+            return $this->getCredentialsFromFormData($data);
+        }
+    };
+
+    $creds = $login->callCredentials(['email' => 'marcel@klassci.com', 'password' => 'secret']);
+
+    expect($creds)->toBe([
+        'email' => 'marcel@klassci.com',
+        'password' => 'secret',
+    ]);
+});
+
+it('maps a username-shaped identifier to the username column', function () {
+    $login = new class extends GroupLogin {
+        public function callCredentials(array $data): array
+        {
+            return $this->getCredentialsFromFormData($data);
+        }
+    };
+
+    $creds = $login->callCredentials(['email' => 'jean.diomande', 'password' => 'secret']);
+
+    expect($creds)->toBe([
+        'username' => 'jean.diomande',
+        'password' => 'secret',
+    ]);
+});
+
+it('trims surrounding whitespace before classifying', function () {
+    $login = new class extends GroupLogin {
+        public function callCredentials(array $data): array
+        {
+            return $this->getCredentialsFromFormData($data);
+        }
+    };
+
+    $creds = $login->callCredentials(['email' => '  marcel@klassci.com  ', 'password' => 'x']);
+
+    expect($creds['email'])->toBe('marcel@klassci.com')
+        ->and(array_key_exists('username', $creds))->toBeFalse();
+});

--- a/tests/Feature/Group/UsernameFallbackTest.php
+++ b/tests/Feature/Group/UsernameFallbackTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMember;
+use App\Services\Group\UsernameGenerator;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    $this->group = Group::create(['name' => 'Test Group', 'code' => 'test-uname', 'status' => 'active']);
+});
+
+function makeMember(int $groupId, array $overrides = []): GroupMember
+{
+    return GroupMember::create(array_merge([
+        'group_id' => $groupId,
+        'name' => 'Jean Diomandé',
+        'email' => 'jean@test.fr',
+        'password' => 'x',
+        'role' => 'fondateur',
+        'is_active' => true,
+    ], $overrides));
+}
+
+it('does NOT generate a username when an email is provided', function () {
+    $member = makeMember($this->group->id, ['email' => 'withemail@test.fr']);
+
+    expect($member->refresh()->username)->toBeNull();
+});
+
+it('auto-generates a username when email is missing', function () {
+    $member = makeMember($this->group->id, [
+        'name' => 'Jean Diomandé',
+        'email' => null,
+    ]);
+
+    expect($member->refresh()->username)->toBe('jean.diomande');
+});
+
+it('dedups colliding usernames with a numeric suffix', function () {
+    makeMember($this->group->id, ['name' => 'Jean Diomandé', 'email' => null]);
+    $second = makeMember($this->group->id, [
+        'name' => 'Jean Diomandé',
+        'email' => null,
+    ]);
+
+    expect($second->refresh()->username)->toBe('jean.diomande.2');
+});
+
+it('strips accents and diacritics', function () {
+    $member = makeMember($this->group->id, [
+        'name' => 'Éléonore Koffié',
+        'email' => null,
+    ]);
+
+    expect($member->refresh()->username)->toBe('eleonore.koffie');
+});
+
+it('collapses three-part names to first.last', function () {
+    $member = makeMember($this->group->id, [
+        'name' => 'Jean Baptiste Diomandé',
+        'email' => null,
+    ]);
+
+    expect($member->refresh()->username)->toBe('jean.diomande');
+});
+
+it('honours an explicit username supplied by the admin', function () {
+    $member = makeMember($this->group->id, [
+        'name' => 'Whatever',
+        'email' => null,
+        'username' => 'custom.handle',
+    ]);
+
+    expect($member->refresh()->username)->toBe('custom.handle');
+});
+
+it('falls back to a random suffix when the name is pathological', function () {
+    $member = makeMember($this->group->id, [
+        'name' => '!!!',
+        'email' => null,
+    ]);
+
+    // Random fallback starts with "membre."
+    expect($member->refresh()->username)->toStartWith('membre.');
+});
+
+it('UsernameGenerator service generates a deterministic slug from a name', function () {
+    $generator = new UsernameGenerator();
+
+    expect($generator->generate('Marie Kouadio'))->toBe('marie.kouadio');
+});
+
+it('UsernameGenerator appends .2 when the base is taken', function () {
+    makeMember($this->group->id, ['name' => 'Paul Koffi', 'email' => null]);
+
+    $generator = new UsernameGenerator();
+
+    expect($generator->generate('Paul Koffi'))->toBe('paul.koffi.2');
+});


### PR DESCRIPTION
Closes #56

## Summary

Rend l'email optionnel sur group_members : quand un admin invite un DGA hiré d'une filiale sans email pro, un username est auto-généré depuis le nom et le membre peut login avec à la place.

## Changes

| Fichier | Changement |
|---------|-----------|
| Migration | email NULL, add username VARCHAR(80) NULL UNIQUE (raw ALTER — Doctrine DBAL drop unique sur nullable change) |
| `UsernameGenerator` | `Str::slug` → `prenom.nom`, collapse 3-parts to first+last, strip accents, collision dedup `.2/.3` |
| `GroupMemberObserver::creating` | Auto-gen username si email+username blank (single INSERT) |
| `GroupLogin` | Relabel input → "Email ou nom d'utilisateur". `getCredentialsFromFormData` avec `filter_var` → mappe email OU username |
| `MembersRelationManager` | Email optionnel + helper, username visible, description `@username` dans table |
| Artisan `group-portal:reset-password {identifier}` | Print temp password stdout pour delivery OOB (Filament reset requires email) |

## Tests (313 total / 845 assertions)

- 9 feature UsernameFallback
- 3 feature GroupLoginCredentials

## Quality Gate 4 axes

| Axe | Verdict |
|-----|---------|
| Architecture | PASS — UsernameGenerator SRP service, Observer creating hook clean |
| Qualité vs Vitesse | PASS — 12 new tests couvrant collision + accents + pathological input |
| Production-grade | PASS — migration rollback safeguarded, artisan fallback pour username-only users |
| SOLID | PASS — `getCredentialsFromFormData` Filament native hook (pas de fork de Login page) |

Session: plan-and-confirm 2026-04-22 (PR C of 3 — DGA ✅ / Invitation flow ✅ / Username fallback).

## Type

feat