### PR TITLE
chore(group-portal): simplify onboarding code post-review

### DIFF
--- a/app/Console/Commands/ResetGroupMemberPassword.php
+++ b/app/Console/Commands/ResetGroupMemberPassword.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use App\Models\GroupMember;
 use App\Services\Group\TemporaryPasswordGenerator;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Hash;
 
 /**
  * Fallback for members without email — the Filament password-reset link
@@ -24,7 +23,7 @@ class ResetGroupMemberPassword extends Command
 
     public function handle(TemporaryPasswordGenerator $generator): int
     {
-        $identifier = (string) $this->argument('identifier');
+        $identifier = $this->argument('identifier');
 
         $member = $this->resolveMember($identifier);
 
@@ -35,20 +34,15 @@ class ResetGroupMemberPassword extends Command
         }
 
         $tempPassword = $generator->generate();
+        $member->resetToTemporaryPassword($tempPassword);
 
-        $member->forceFill([
-            'password' => Hash::make($tempPassword),
-            'password_changed_at' => null,
-            'invitation_token' => null,
-        ])->save();
-
-        $this->line('');
+        $this->newLine();
         $this->info("Password reset for {$member->name} ({$member->email} / @{$member->username}).");
-        $this->line('');
+        $this->newLine();
         $this->line('  Mot de passe temporaire :');
-        $this->line('');
+        $this->newLine();
         $this->line("    <fg=yellow;options=bold>{$tempPassword}</>");
-        $this->line('');
+        $this->newLine();
         $this->warn('  Transmettez ce mot de passe au membre par un canal sécurisé.');
         $this->warn('  Il sera invité à le changer dès la première connexion.');
 

--- a/app/Enums/GroupMemberRole.php
+++ b/app/Enums/GroupMemberRole.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Single source of truth for group_members.role values.
+ *
+ * Every downstream concern (dropdown options, badge colors, label
+ * formatting, role-based alert matching, model helpers) derives from this
+ * enum so adding a role is a one-file change instead of the 4-site edit
+ * that the original string-based approach required.
+ */
+enum GroupMemberRole: string
+{
+    case Fondateur = 'fondateur';
+    case DirecteurGeneral = 'directeur_general';
+    case DirecteurGeneralAdjoint = 'directeur_general_adjoint';
+    case DirecteurFinancier = 'directeur_financier';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Fondateur => 'Fondateur',
+            self::DirecteurGeneral => 'Directeur Général',
+            self::DirecteurGeneralAdjoint => 'Directeur Général Adjoint',
+            self::DirecteurFinancier => 'Directeur Financier',
+        };
+    }
+
+    public function badgeColor(): string
+    {
+        return match ($this) {
+            self::Fondateur => 'success',
+            self::DirecteurGeneral => 'primary',
+            self::DirecteurGeneralAdjoint => 'info',
+            self::DirecteurFinancier => 'warning',
+        };
+    }
+
+    /**
+     * True for roles that share full operational oversight — they receive
+     * every AlertType by default. CFOs (DirecteurFinancier) are excluded:
+     * the AlertRoleMatcher routes them to financial alerts only.
+     */
+    public function hasOperationalOversight(): bool
+    {
+        return match ($this) {
+            self::Fondateur,
+            self::DirecteurGeneral,
+            self::DirecteurGeneralAdjoint => true,
+            self::DirecteurFinancier => false,
+        };
+    }
+
+    /**
+     * @return array<string,string> [value => label] — ready for Filament
+     *  Select options, config seeds, or API responses.
+     */
+    public static function options(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->value] = $case->label();
+        }
+
+        return $options;
+    }
+}

--- a/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\GroupResource\RelationManagers;
 
+use App\Enums\GroupMemberRole;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -55,14 +56,9 @@ class MembersRelationManager extends RelationManager
 
                 Forms\Components\Select::make('role')
                     ->label('Rôle')
-                    ->options([
-                        'fondateur' => 'Fondateur',
-                        'directeur_general' => 'Directeur Général',
-                        'directeur_general_adjoint' => 'Directeur Général Adjoint',
-                        'directeur_financier' => 'Directeur Financier',
-                    ])
+                    ->options(GroupMemberRole::options())
                     ->required()
-                    ->default('fondateur'),
+                    ->default(GroupMemberRole::Fondateur->value),
 
                 Forms\Components\TextInput::make('phone')
                     ->label('Téléphone')
@@ -93,20 +89,8 @@ class MembersRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('role')
                     ->label('Rôle')
                     ->badge()
-                    ->color(fn (string $state): string => match ($state) {
-                        'fondateur' => 'success',
-                        'directeur_general' => 'primary',
-                        'directeur_general_adjoint' => 'info',
-                        'directeur_financier' => 'warning',
-                        default => 'gray',
-                    })
-                    ->formatStateUsing(fn (string $state): string => match ($state) {
-                        'fondateur' => 'Fondateur',
-                        'directeur_general' => 'Directeur Général',
-                        'directeur_general_adjoint' => 'Directeur Général Adjoint',
-                        'directeur_financier' => 'Directeur Financier',
-                        default => $state,
-                    }),
+                    ->color(fn (string $state): string => GroupMemberRole::tryFrom($state)?->badgeColor() ?? 'gray')
+                    ->formatStateUsing(fn (string $state): string => GroupMemberRole::tryFrom($state)?->label() ?? $state),
 
                 Tables\Columns\IconColumn::make('is_active')
                     ->label('Actif')

--- a/app/Http/Controllers/Group/SetPasswordController.php
+++ b/app/Http/Controllers/Group/SetPasswordController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Group;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\View\View;
 
@@ -46,13 +45,7 @@ class SetPasswordController extends Controller
             ],
         ]);
 
-        $member = auth('group')->user();
-
-        $member->forceFill([
-            'password' => Hash::make($validated['password']),
-            'password_changed_at' => now(),
-            'invitation_token' => null,
-        ])->save();
+        auth('group')->user()->recordPasswordRotation($validated['password']);
 
         session()->forget('gp_invitation_member_id');
 

--- a/app/Http/Middleware/EnsurePasswordChanged.php
+++ b/app/Http/Middleware/EnsurePasswordChanged.php
@@ -15,11 +15,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class EnsurePasswordChanged
 {
-    /**
-     * Routes allowed even when the user still has password_changed_at = null.
-     * Named routes resolved via `routeIs()` which supports wildcards — the
-     * Filament logout endpoint is registered as `filament.group.auth.logout`.
-     */
+    // Routes allowed even while password_changed_at is null — without these,
+    // the redirect loops and the user can't bail out via logout.
     private const EXEMPT_ROUTE_PATTERNS = [
         'filament.group.auth.logout',
         'groupe.set-password*',
@@ -29,18 +26,12 @@ class EnsurePasswordChanged
     {
         $user = auth('group')->user();
 
-        if ($user === null || ! method_exists($user, 'mustChangePassword')) {
+        if ($user === null || ! $user->mustChangePassword()) {
             return $next($request);
         }
 
-        if (! $user->mustChangePassword()) {
+        if ($request->routeIs(self::EXEMPT_ROUTE_PATTERNS)) {
             return $next($request);
-        }
-
-        foreach (self::EXEMPT_ROUTE_PATTERNS as $pattern) {
-            if ($request->routeIs($pattern)) {
-                return $next($request);
-            }
         }
 
         return redirect()->route('groupe.set-password.show');

--- a/app/Mail/Concerns/TracksBounces.php
+++ b/app/Mail/Concerns/TracksBounces.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Mail\Concerns;
+
+use App\Services\Group\BounceTracker;
+
+/**
+ * Shared `failed()` hook for every Mailable addressed to a GroupMember.
+ *
+ * The consumer must expose `$this->member` — both `AbstractGroupAlertMail`
+ * and `GroupMemberInvitationMail` do. Keeps the bounce-tracking policy in
+ * one spot: if we later rewrite the tracker (webhook-based bounce, external
+ * provider), only this trait and BounceTracker itself change.
+ */
+trait TracksBounces
+{
+    public function failed(\Throwable $exception): void
+    {
+        app(BounceTracker::class)->recordFailure($this->member, $exception);
+    }
+}

--- a/app/Mail/Group/AbstractGroupAlertMail.php
+++ b/app/Mail/Group/AbstractGroupAlertMail.php
@@ -2,9 +2,9 @@
 
 namespace App\Mail\Group;
 
+use App\Mail\Concerns\TracksBounces;
 use App\Models\Group;
 use App\Models\GroupMember;
-use App\Services\Group\BounceTracker;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\URL;
  */
 abstract class AbstractGroupAlertMail extends Mailable implements ShouldQueue
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, TracksBounces;
 
     public int $tries = 3;
 
@@ -43,17 +43,5 @@ abstract class AbstractGroupAlertMail extends Mailable implements ShouldQueue
             'member' => $this->member->id,
             'type' => $type,
         ]);
-    }
-
-    /**
-     * Fires after the queue worker exhausts `$tries` retries. Delegates to
-     * BounceTracker which inspects the exception's SMTP code and decides
-     * whether to count it toward auto-disable (hard bounce) or just log it
-     * (soft bounce). Kept here (not on each subclass) so all alert Mailables
-     * honour the same bounce policy without repetition.
-     */
-    public function failed(\Throwable $exception): void
-    {
-        app(BounceTracker::class)->recordFailure($this->member, $exception);
     }
 }

--- a/app/Mail/Group/GroupMemberInvitationMail.php
+++ b/app/Mail/Group/GroupMemberInvitationMail.php
@@ -2,8 +2,8 @@
 
 namespace App\Mail\Group;
 
+use App\Mail\Concerns\TracksBounces;
 use App\Models\GroupMember;
-use App\Services\Group\BounceTracker;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -19,7 +19,7 @@ use Illuminate\Queue\SerializesModels;
  */
 class GroupMemberInvitationMail extends Mailable implements ShouldQueue
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, TracksBounces;
 
     public int $tries = 3;
 
@@ -44,8 +44,4 @@ class GroupMemberInvitationMail extends Mailable implements ShouldQueue
             ]);
     }
 
-    public function failed(\Throwable $exception): void
-    {
-        app(BounceTracker::class)->recordFailure($this->member, $exception);
-    }
 }

--- a/app/Models/GroupMember.php
+++ b/app/Models/GroupMember.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use App\Enums\GroupMemberRole;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
 use Filament\Panel;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 class GroupMember extends Authenticatable implements FilamentUser, HasName
 {
@@ -43,14 +45,59 @@ class GroupMember extends Authenticatable implements FilamentUser, HasName
         'invitation_sent_at' => 'datetime',
     ];
 
-    /**
-     * True when the member still needs to change their password before
-     * using the portal. New invitations land here until the user completes
-     * the set-password flow.
-     */
     public function mustChangePassword(): bool
     {
         return $this->password_changed_at === null;
+    }
+
+    public function roleEnum(): ?GroupMemberRole
+    {
+        return GroupMemberRole::tryFrom((string) $this->role);
+    }
+
+    /**
+     * Writes a newly minted temporary password + invitation token hash,
+     * leaving `password_changed_at` null so EnsurePasswordChanged traps
+     * the next login. Returns the model for fluent use.
+     */
+    public function assignInvitationCredentials(string $plainPassword, string $tokenHash): self
+    {
+        $this->forceFill([
+            'password' => Hash::make($plainPassword),
+            'password_changed_at' => null,
+            'invitation_token' => $tokenHash,
+            'invitation_sent_at' => now(),
+        ])->save();
+
+        return $this;
+    }
+
+    public function recordPasswordRotation(string $plainPassword): self
+    {
+        $this->forceFill([
+            'password' => Hash::make($plainPassword),
+            'password_changed_at' => now(),
+            'invitation_token' => null,
+        ])->save();
+
+        return $this;
+    }
+
+    /**
+     * Used by the admin-side reset command when a username-only member
+     * needs a new temp password delivered out-of-band. Mirrors invitation
+     * state (password_changed_at null) but clears the URL token since no
+     * new signed URL is issued.
+     */
+    public function resetToTemporaryPassword(string $plainPassword): self
+    {
+        $this->forceFill([
+            'password' => Hash::make($plainPassword),
+            'password_changed_at' => null,
+            'invitation_token' => null,
+        ])->save();
+
+        return $this;
     }
 
     public function group()
@@ -66,21 +113,6 @@ class GroupMember extends Authenticatable implements FilamentUser, HasName
     public function getFilamentName(): string
     {
         return $this->name;
-    }
-
-    public function isFondateur(): bool
-    {
-        return $this->role === 'fondateur';
-    }
-
-    public function isDirecteurGeneral(): bool
-    {
-        return $this->role === 'directeur_general';
-    }
-
-    public function isDirecteurGeneralAdjoint(): bool
-    {
-        return $this->role === 'directeur_general_adjoint';
     }
 
     public function getGroupTenants()

--- a/app/Observers/GroupMemberObserver.php
+++ b/app/Observers/GroupMemberObserver.php
@@ -5,8 +5,6 @@ namespace App\Observers;
 use App\Models\GroupMember;
 use App\Services\Group\GroupMemberInvitationService;
 use App\Services\Group\UsernameGenerator;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 /**
  * Triggers the invitation flow for newly created members. Runs via the

--- a/app/Services/Group/AlertRoleMatcher.php
+++ b/app/Services/Group/AlertRoleMatcher.php
@@ -3,17 +3,18 @@
 namespace App\Services\Group;
 
 use App\Enums\AlertType;
+use App\Enums\GroupMemberRole;
 
 /**
  * Decides whether a given `GroupMember` role should receive a specific
  * `AlertType`. Strategy pattern — the matrix is data, not conditionals
  * scattered through the dispatcher.
  *
- * Defaults: `fondateur` and `directeur_general` get everything (full
- * operational oversight). `directeur_financier` gets only alerts that
- * directly affect cash — subscription expiry, unpaid invoices, reliquats,
- * quota issues that block billing. SSL / stale tenant / teacher workload
- * are ops signals, noise for a CFO.
+ * Defaults: operational-oversight roles (fondateur, directeur_general,
+ * directeur_general_adjoint) get everything. `directeur_financier` gets
+ * only alerts that directly affect cash — subscription expiry, unpaid
+ * invoices, reliquats, quota issues that block billing. SSL / stale tenant
+ * / teacher workload are ops signals, noise for a CFO.
  */
 class AlertRoleMatcher
 {
@@ -29,12 +30,17 @@ class AlertRoleMatcher
 
     public function isSubscribed(string $role, AlertType $type): bool
     {
-        return match ($role) {
-            // DGA shares the founder/DG operational oversight scope — they
-            // act as the DG's proxy and must see every alert the DG would.
-            'fondateur', 'directeur_general', 'directeur_general_adjoint' => true,
-            'directeur_financier' => in_array($type, self::FINANCIAL_ROLE_ALERTS, true),
-            default => false,
-        };
+        $enum = GroupMemberRole::tryFrom($role);
+
+        if ($enum === null) {
+            return false;
+        }
+
+        if ($enum->hasOperationalOversight()) {
+            return true;
+        }
+
+        return $enum === GroupMemberRole::DirecteurFinancier
+            && in_array($type, self::FINANCIAL_ROLE_ALERTS, true);
     }
 }

--- a/app/Services/Group/GroupMemberInvitationService.php
+++ b/app/Services/Group/GroupMemberInvitationService.php
@@ -4,7 +4,6 @@ namespace App\Services\Group;
 
 use App\Mail\Group\GroupMemberInvitationMail;
 use App\Models\GroupMember;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\URL;
@@ -50,12 +49,7 @@ class GroupMemberInvitationService
         $password = $this->passwordGenerator->generate();
         $rawToken = Str::random(64);
 
-        $member->forceFill([
-            'password' => Hash::make($password),
-            'password_changed_at' => null,
-            'invitation_token' => hash('sha256', $rawToken),
-            'invitation_sent_at' => now(),
-        ])->save();
+        $member->assignInvitationCredentials($password, hash('sha256', $rawToken));
 
         $activationUrl = $this->buildActivationUrl($member, $rawToken);
 


### PR DESCRIPTION
Post-review cleanup des 3 PRs onboarding (#53, #55, #57). Zero behavior change, 313 tests passent.

- `App\Enums\GroupMemberRole` — single source role options/labels/badge/oversight matrix (-4 sites dupliqués)
- 3 model methods (`assignInvitationCredentials`, `recordPasswordRotation`, `resetToTemporaryPassword`) remplacent 3 `forceFill` dupliqués
- `TracksBounces` trait mutualise le `failed()` hook entre AbstractGroupAlertMail + GroupMemberInvitationMail
- Middleware : drop `method_exists` dead check (group guard hard-wired à GroupMember)
- Artisan : `$this->newLine()` > 4× `$this->line('')`
- Cleanup imports inutilisés (Hash facade)
- Drop 3 isXxx helpers (0 caller)